### PR TITLE
allow CRAM without SCRAM

### DIFF
--- a/indimail-x/authindi.c
+++ b/indimail-x/authindi.c
@@ -1,5 +1,5 @@
 /*
- * $Id: $
+ * $Id: authindi.c,v 1.18 2023-07-15 00:16:08+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -57,7 +57,7 @@
 #define WARN  "authindi: warn: "
 
 #ifndef lint
-static char     sccsid[] = "$Id: authindi.c,v 1.17 2023-06-17 23:46:55+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: authindi.c,v 1.18 2023-07-15 00:16:08+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static stralloc tmpbuf = {0};
@@ -593,7 +593,7 @@ main(int argc, char **argv)
 	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
 		pw->pw_passwd += 6;
 		cleartxt = pw->pw_passwd;
-		i = str_rchr(pw->pw_passwd, ':');
+		i = str_rchr(pw->pw_passwd, ',');
 		if (pw->pw_passwd[i]) {
 			pw->pw_passwd[i] = 0;
 			pw->pw_passwd += (i + 1);
@@ -686,6 +686,9 @@ main(int argc, char **argv)
 
 /*
  * $Log: authindi.c,v $
+ * Revision 1.18  2023-07-15 00:16:08+05:30  Cprogrammer
+ * authenticate using CRAM when password field starts with {CRAM}
+ *
  * Revision 1.17  2023-06-17 23:46:55+05:30  Cprogrammer
  * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
  *

--- a/indimail-x/gsasl_mkpasswd.c
+++ b/indimail-x/gsasl_mkpasswd.c
@@ -67,7 +67,8 @@ const char     *gsasl_mkpasswd_err(int err)
 }
 
 int
-gsasl_mkpasswd(int verbose, char *mechanism, int iteration_count, char *b64salt_arg, int docram, char *cleartxt, stralloc *result)
+gsasl_mkpasswd(int verbose, char *mechanism, int iteration_count,
+		char *b64salt_arg, int docram, char *cleartxt, stralloc *result)
 {
 	char            salt_buf[DEFAULT_SALT_SIZE];
 	char           *salt, *hexsaltedpassword, *b64salt;

--- a/indimail-x/gsasl_mkpasswd.c
+++ b/indimail-x/gsasl_mkpasswd.c
@@ -1,5 +1,8 @@
 /*
  * $Log: gsasl_mkpasswd.c,v $
+ * Revision 1.7  2023-07-15 00:16:40+05:30  Cprogrammer
+ * formatted long line
+ *
  * Revision 1.6  2022-08-28 11:43:19+05:30  Cprogrammer
  * fixed null terminatin when docram was 0
  *
@@ -41,7 +44,7 @@
 #include "gsasl_mkpasswd.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: gsasl_mkpasswd.c,v 1.6 2022-08-28 11:43:19+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: gsasl_mkpasswd.c,v 1.7 2023-07-15 00:16:40+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef HAVE_GSASL

--- a/indimail-x/iauth.c
+++ b/indimail-x/iauth.c
@@ -1,5 +1,5 @@
 /*
- * $Id: $
+ * $Id: iauth.c,v 1.9 2023-07-15 00:17:48+05:30 Cprogrammer Exp mbhangui $
  *
  * authenticate.c - Generic PAM Authentication module for pam_multi
  * Copyright (C) <2008-2023>  Manvendra Bhangui <manvendra@indimail.org>
@@ -81,7 +81,7 @@
 #include "common.h"
 
 #ifndef lint
-static char     sccsid[] = "$Id: iauth.c,v 1.8 2022-10-29 21:36:14+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: iauth.c,v 1.9 2023-07-15 00:17:48+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static int      defaultTask(char *, char *, struct passwd *, char *, int);
@@ -183,7 +183,7 @@ i_auth(char *email, char *service, int *size, int debug)
 		}
 	} else
 	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
-		i = str_rchr(pw->pw_passwd, ':');
+		i = str_rchr(pw->pw_passwd, ',');
 		if (pw->pw_passwd[i])
 			pw->pw_passwd += (i + 1);
 		else
@@ -468,6 +468,9 @@ defaultTask(char *email, char *TheDomain, struct passwd *pw, char *service, int 
 
 /*
  * $Log: iauth.c,v $
+ * Revision 1.9  2023-07-15 00:17:48+05:30  Cprogrammer
+ * authenticate using CRAM when password field starts with {CRAM}
+ *
  * Revision 1.8  2022-10-29 21:36:14+05:30  Cprogrammer
  * removed compiler warning for unused variable
  *

--- a/indimail-x/proxylogin.c
+++ b/indimail-x/proxylogin.c
@@ -1,38 +1,5 @@
 /*
- * $Log: proxylogin.c,v $
- * Revision 1.11  2023-06-17 23:47:44+05:30  Cprogrammer
- * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
- *
- * Revision 1.10  2023-01-03 21:48:21+05:30  Cprogrammer
- * added crlfile argument for auth_admin()
- *
- * Revision 1.9  2022-12-25 12:13:29+05:30  Cprogrammer
- * authenticate using SCRAM salted password
- *
- * Revision 1.8  2022-08-05 21:12:37+05:30  Cprogrammer
- * added encrypt_flag argument to autoAddUser()
- *
- * Revision 1.7  2021-07-22 15:17:27+05:30  Cprogrammer
- * conditional define of _XOPEN_SOURCE
- *
- * Revision 1.6  2021-03-04 12:45:18+05:30  Cprogrammer
- * added option to specify CAFILE and match host with common name
- *
- * Revision 1.5  2020-10-01 18:28:17+05:30  Cprogrammer
- * fixed compiler warnings
- *
- * Revision 1.4  2020-04-01 18:57:32+05:30  Cprogrammer
- * added encrypt flag to mkpasswd()
- *
- * Revision 1.3  2019-06-07 16:02:39+05:30  mbhangui
- * replaced getenv() with env_get()
- *
- * Revision 1.2  2019-04-22 23:14:42+05:30  Cprogrammer
- * replaced atoi() with scan_int()
- *
- * Revision 1.1  2019-04-18 15:48:27+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -67,9 +34,6 @@ static char     sccsid[] = "$Id: proxylogin.c,v 1.11 2023-06-17 23:47:44+05:30 C
 #include <pw_comp.h>
 #include <getEnvConfig.h>
 #include <get_scram_secrets.h>
-#endif
-#ifdef HAVE_GSASL
-#include <gsasl.h>
 #endif
 #include "runcmmd.h"
 #include "auth_admin.h"
@@ -184,11 +148,7 @@ LocalLogin(char **argv, char *email, char *TheUser, char *TheDomain, char *servi
 	char *imaptag, char *plaintext)
 {
 	char           *p, *crypt_pass;
-#ifdef HAVE_GSASL
-#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
 	int             i;
-#endif
-#endif
 	struct passwd  *pw;
 
 	if (!(pw = inquery(PWD_QUERY, email, 0))) {
@@ -230,8 +190,6 @@ LocalLogin(char **argv, char *email, char *TheUser, char *TheDomain, char *servi
 	}
 	p = plaintext;
 	remove_quotes(&p);
-#ifdef HAVE_GSASL
-#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
 	crypt_pass = (char *) NULL;
 	if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-1}", 13) || !str_diffn(pw->pw_passwd, "{SCRAM-SHA-256}", 15)) {
 		i = get_scram_secrets(pw->pw_passwd, 0, 0, 0, 0, 0, 0, 0, &crypt_pass);
@@ -239,16 +197,16 @@ LocalLogin(char **argv, char *email, char *TheUser, char *TheDomain, char *servi
 			strerr_warn1("proxylogin: unable to get secrets", 0);
 			return (-1);
 		}
-	} else {
-		i = 0;
+	} else
+	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
+		i = str_rchr(pw->pw_passwd, ':');
+		if (pw->pw_passwd[i])
+			pw->pw_passwd += (i + 1);
+		else
+			pw->pw_passwd += 6;
 		crypt_pass = pw->pw_passwd;
-	}
-#else
-	crypt_pass = pw->pw_passwd;
-#endif
-#else
-	crypt_pass = pw->pw_passwd;
-#endif
+	} else
+		crypt_pass = pw->pw_passwd;
 	if (!env_get("PASSWORD_HASH") && !env_put2("PASSWORD_HASH", "0"))
 		die_nomem();
 	if (pw->pw_passwd[0] && !pw_comp(0, (unsigned char *) crypt_pass, 0, (unsigned char *) p, 0)) {
@@ -672,3 +630,40 @@ void pop3d_capability()
 	out("proxylogin", "TOP\r\nUSER\r\nLOGIN-DELAY 10\r\nPIPELINING\r\nUIDL\r\n.\r\n");
 	flush("proxylogin");
 }
+
+/*
+ * $Log: proxylogin.c,v $
+ * Revision 1.11  2023-06-17 23:47:44+05:30  Cprogrammer
+ * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
+ *
+ * Revision 1.10  2023-01-03 21:48:21+05:30  Cprogrammer
+ * added crlfile argument for auth_admin()
+ *
+ * Revision 1.9  2022-12-25 12:13:29+05:30  Cprogrammer
+ * authenticate using SCRAM salted password
+ *
+ * Revision 1.8  2022-08-05 21:12:37+05:30  Cprogrammer
+ * added encrypt_flag argument to autoAddUser()
+ *
+ * Revision 1.7  2021-07-22 15:17:27+05:30  Cprogrammer
+ * conditional define of _XOPEN_SOURCE
+ *
+ * Revision 1.6  2021-03-04 12:45:18+05:30  Cprogrammer
+ * added option to specify CAFILE and match host with common name
+ *
+ * Revision 1.5  2020-10-01 18:28:17+05:30  Cprogrammer
+ * fixed compiler warnings
+ *
+ * Revision 1.4  2020-04-01 18:57:32+05:30  Cprogrammer
+ * added encrypt flag to mkpasswd()
+ *
+ * Revision 1.3  2019-06-07 16:02:39+05:30  mbhangui
+ * replaced getenv() with env_get()
+ *
+ * Revision 1.2  2019-04-22 23:14:42+05:30  Cprogrammer
+ * replaced atoi() with scan_int()
+ *
+ * Revision 1.1  2019-04-18 15:48:27+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/proxylogin.c
+++ b/indimail-x/proxylogin.c
@@ -1,12 +1,12 @@
 /*
- * $Id: $
+ * $Id: proxylogin.c,v 1.12 2023-07-15 00:18:05+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 #ifndef	lint
-static char     sccsid[] = "$Id: proxylogin.c,v 1.11 2023-06-17 23:47:44+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: proxylogin.c,v 1.12 2023-07-15 00:18:05+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef CLUSTERED_SITE
@@ -199,7 +199,7 @@ LocalLogin(char **argv, char *email, char *TheUser, char *TheDomain, char *servi
 		}
 	} else
 	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
-		i = str_rchr(pw->pw_passwd, ':');
+		i = str_rchr(pw->pw_passwd, ',');
 		if (pw->pw_passwd[i])
 			pw->pw_passwd += (i + 1);
 		else
@@ -633,6 +633,9 @@ void pop3d_capability()
 
 /*
  * $Log: proxylogin.c,v $
+ * Revision 1.12  2023-07-15 00:18:05+05:30  Cprogrammer
+ * authenticate using CRAM when password field starts with {CRAM}
+ *
  * Revision 1.11  2023-06-17 23:47:44+05:30  Cprogrammer
  * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
  *

--- a/indimail-x/renameuser.c
+++ b/indimail-x/renameuser.c
@@ -1,26 +1,5 @@
 /*
- * $Log: renameuser.c,v $
- * Revision 1.7  2023-03-23 22:35:13+05:30  Cprogrammer
- * ignore duplicate error when updating lastauth table
- *
- * Revision 1.6  2022-11-02 14:56:35+05:30  Cprogrammer
- * restore scram password while renaming user
- *
- * Revision 1.5  2022-09-14 08:47:36+05:30  Cprogrammer
- * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
- *
- * Revision 1.4  2022-08-05 22:57:27+05:30  Cprogrammer
- * removed apop argument to iadduser()
- *
- * Revision 1.3  2022-08-05 21:14:38+05:30  Cprogrammer
- * added encrypt_flag argument to iadduser()
- *
- * Revision 1.2  2021-09-12 20:17:53+05:30  Cprogrammer
- * moved replacestr to libqmail
- *
- * Revision 1.1  2019-04-15 12:36:45+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: renameuser.c,v 1.8 2023-07-15 00:19:31+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -60,7 +39,7 @@
 #include "deluser.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: renameuser.c,v 1.7 2023-03-23 22:35:13+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: renameuser.c,v 1.8 2023-07-15 00:19:31+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static void
@@ -192,7 +171,7 @@ renameuser(stralloc *oldUser, stralloc *oldDomain, stralloc *newUser, stralloc *
 		pw->pw_passwd = enc_pass;
 	} else
 	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
-		i = str_rchr(pw->pw_passwd, ':');
+		i = str_rchr(pw->pw_passwd, ',');
 		if (pw->pw_passwd[i]) {
 			if (!stralloc_copyb(&scram, pw->pw_passwd, i) ||
 					!stralloc_0(&scram))
@@ -338,3 +317,31 @@ renameuser(stralloc *oldUser, stralloc *oldDomain, stralloc *newUser, stralloc *
 		return (-1);
 	return (0);
 }
+
+/*
+ * $Log: renameuser.c,v $
+ * Revision 1.8  2023-07-15 00:19:31+05:30  Cprogrammer
+ * copy scram field from old user to new user when renaming user
+ *
+ * Revision 1.7  2023-03-23 22:35:13+05:30  Cprogrammer
+ * ignore duplicate error when updating lastauth table
+ *
+ * Revision 1.6  2022-11-02 14:56:35+05:30  Cprogrammer
+ * restore scram password while renaming user
+ *
+ * Revision 1.5  2022-09-14 08:47:36+05:30  Cprogrammer
+ * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
+ *
+ * Revision 1.4  2022-08-05 22:57:27+05:30  Cprogrammer
+ * removed apop argument to iadduser()
+ *
+ * Revision 1.3  2022-08-05 21:14:38+05:30  Cprogrammer
+ * added encrypt_flag argument to iadduser()
+ *
+ * Revision 1.2  2021-09-12 20:17:53+05:30  Cprogrammer
+ * moved replacestr to libqmail
+ *
+ * Revision 1.1  2019-04-15 12:36:45+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/sql_getpw.c
+++ b/indimail-x/sql_getpw.c
@@ -1,5 +1,5 @@
 /*
- * $Id: $
+ * $Id: sql_getpw.c,v 1.4 2023-07-15 00:21:26+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -27,7 +27,7 @@
 #include "strToPw.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: sql_getpw.c,v 1.3 2022-10-27 17:14:31+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: sql_getpw.c,v 1.4 2023-07-15 00:21:26+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef QUERY_CACHE
@@ -221,6 +221,9 @@ sql_getpw_cache(char cache_switch)
 
 /*
  * $Log: sql_getpw.c,v $
+ * Revision 1.4  2023-07-15 00:21:26+05:30  Cprogrammer
+ * updated comments
+ *
  * Revision 1.3  2022-10-27 17:14:31+05:30  Cprogrammer
  * refactored sql code into do_sql()
  *

--- a/indimail-x/sql_getpw.c
+++ b/indimail-x/sql_getpw.c
@@ -1,14 +1,5 @@
 /*
- * $Log: sql_getpw.c,v $
- * Revision 1.3  2022-10-27 17:14:31+05:30  Cprogrammer
- * refactored sql code into do_sql()
- *
- * Revision 1.2  2022-08-04 14:41:49+05:30  Cprogrammer
- * fetch scram password
- *
- * Revision 1.1  2019-04-18 15:49:41+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -175,10 +166,10 @@ sql_getpw(char *user, char *domain)
 		if (!stralloc_copy(&IDomain, &_domain) || !stralloc_0(&IDomain))
 			die_nomem();
 		IDomain.len--;
-		if (row[2]) {
-			if (!stralloc_copys(&IPass, row[2]) ||
+		if (row[2]) { /* scram */
+			if (!stralloc_copys(&IPass, row[2]) || /*- scram field */
 					!stralloc_append(&IPass, ",") ||
-					!stralloc_cats(&IPass, row[1]) ||
+					!stralloc_cats(&IPass, row[1]) || /*- pw_passwd field */
 					!stralloc_0(&IPass))
 				die_nomem();
 		} else {
@@ -227,3 +218,16 @@ sql_getpw_cache(char cache_switch)
 	return;
 }
 #endif
+
+/*
+ * $Log: sql_getpw.c,v $
+ * Revision 1.3  2022-10-27 17:14:31+05:30  Cprogrammer
+ * refactored sql code into do_sql()
+ *
+ * Revision 1.2  2022-08-04 14:41:49+05:30  Cprogrammer
+ * fetch scram password
+ *
+ * Revision 1.1  2019-04-18 15:49:41+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/sql_setpw.c
+++ b/indimail-x/sql_setpw.c
@@ -1,26 +1,5 @@
 /*
- * $Log: sql_setpw.c,v $
- * Revision 1.7  2023-03-23 22:17:53+05:30  Cprogrammer
- * bug fix - record not getting updated
- *
- * Revision 1.6  2022-10-27 17:21:01+05:30  Cprogrammer
- * refactored sql code into do_sql()
- *
- * Revision 1.5  2022-09-19 21:15:25+05:30  Cprogrammer
- * fixed password struct getting overwritten with call to sql_getpw
- *
- * Revision 1.4  2022-09-14 08:47:41+05:30  Cprogrammer
- * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
- *
- * Revision 1.3  2022-08-07 13:02:02+05:30  Cprogrammer
- * added scram argument to set scram password
- *
- * Revision 1.2  2021-02-23 21:41:18+05:30  Cprogrammer
- * replaced CREATE TABLE statements with create_table() function
- *
- * Revision 1.1  2019-04-20 08:43:22+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: sql_setpw.c,v 1.8 2023-07-15 00:47:44+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -52,7 +31,7 @@
 #include "create_table.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: sql_setpw.c,v 1.7 2023-03-23 22:17:53+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: sql_setpw.c,v 1.8 2023-07-15 00:47:44+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 static void
@@ -173,7 +152,7 @@ sql_setpw(struct passwd *inpw, char *domain, char *scram)
 				return (0);
 		} else
 		if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
-			i = str_rchr(pw->pw_passwd, ':');
+			i = str_rchr(pw->pw_passwd, ',');
 			if (pw->pw_passwd[i]) {
 				if (!stralloc_copyb(&result, pw->pw_passwd, i) ||
 						!stralloc_0(&result))
@@ -211,3 +190,31 @@ sql_setpw(struct passwd *inpw, char *domain, char *scram)
 	}
 	return (0);
 }
+
+/*
+ * $Log: sql_setpw.c,v $
+ * Revision 1.8  2023-07-15 00:47:44+05:30  Cprogrammer
+ * extract encrypted password from pw->pw_passwd starting with {CRAM}
+ *
+ * Revision 1.7  2023-03-23 22:17:53+05:30  Cprogrammer
+ * bug fix - record not getting updated
+ *
+ * Revision 1.6  2022-10-27 17:21:01+05:30  Cprogrammer
+ * refactored sql code into do_sql()
+ *
+ * Revision 1.5  2022-09-19 21:15:25+05:30  Cprogrammer
+ * fixed password struct getting overwritten with call to sql_getpw
+ *
+ * Revision 1.4  2022-09-14 08:47:41+05:30  Cprogrammer
+ * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
+ *
+ * Revision 1.3  2022-08-07 13:02:02+05:30  Cprogrammer
+ * added scram argument to set scram password
+ *
+ * Revision 1.2  2021-02-23 21:41:18+05:30  Cprogrammer
+ * replaced CREATE TABLE statements with create_table() function
+ *
+ * Revision 1.1  2019-04-20 08:43:22+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/strToPw.c
+++ b/indimail-x/strToPw.c
@@ -1,20 +1,5 @@
 /*
- * $Log: strToPw.c,v $
- * Revision 1.5  2022-08-25 20:50:25+05:30  Cprogrammer
- * use colon_count to fix logic for cram/non-cram passwords
- *
- * Revision 1.4  2022-08-25 18:11:59+05:30  Cprogrammer
- * handle additional hex salted passwod and clear text password in pw_passwd field
- *
- * Revision 1.3  2022-08-04 14:42:08+05:30  Cprogrammer
- * added comments
- *
- * Revision 1.2  2019-04-16 15:14:19+05:30  Cprogrammer
- * fix for getting all fields
- *
- * Revision 1.1  2019-04-14 20:55:14+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -97,6 +82,13 @@ strToPw(char *pwbuf, int len)
 							break;
 					}
 				}
+			} else
+			if (colon_count > 7 && row_count == 1 && !str_diffn(cptr, "{CRAM}", 6)) {
+				for (ptr += 1; *ptr; ptr++) {
+					if (*ptr == ':') {
+						break;
+					}
+				}
 			}
 			*ptr = 0;
 		} else
@@ -158,3 +150,22 @@ strToPw(char *pwbuf, int len)
 	} /*- for (row_count = 0, cptr = ptr = _pwstruct.s; *ptr; ptr++) */
 	return ((struct passwd *) 0);
 }
+
+/*
+ * $Log: strToPw.c,v $
+ * Revision 1.5  2022-08-25 20:50:25+05:30  Cprogrammer
+ * use colon_count to fix logic for cram/non-cram passwords
+ *
+ * Revision 1.4  2022-08-25 18:11:59+05:30  Cprogrammer
+ * handle additional hex salted passwod and clear text password in pw_passwd field
+ *
+ * Revision 1.3  2022-08-04 14:42:08+05:30  Cprogrammer
+ * added comments
+ *
+ * Revision 1.2  2019-04-16 15:14:19+05:30  Cprogrammer
+ * fix for getting all fields
+ *
+ * Revision 1.1  2019-04-14 20:55:14+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/tests/testindimail-virtual
+++ b/indimail-x/tests/testindimail-virtual
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# $Id: $
+# $Id: testindimail-virtual,v 1.1 2023-07-15 00:14:58+05:30 Cprogrammer Exp mbhangui $
 #
 user=mbhangui
 domain1=example.com
@@ -14,6 +14,7 @@ testuser3=testuser03@$domain1
 testuser4=testuser04@$domain1
 password1="abcdefgh1234"
 password2="abcdefgh2345"
+password3="abcdefgh3456"
 domain=indimail.org
 testdir=/tmp/qmail-test
 servicedir=$testdir/service
@@ -556,6 +557,39 @@ function create_plain_user()
 	fi
 }
 
+function create_cram_user()
+{
+	sudo env - \
+		PATH=/bin:/usr/bin \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+		DOMAINDIR=$qmaildir \
+		SERVICEDIR=$servicedir \
+		vadduser -C -m CRAM -d $1 $2 >> $logdir/setup/vadduser.log
+	status=$?
+
+	if [ $status -eq 0 ] ; then
+		tcount=$(expr $tcount + 1)
+		echo "  testing command vadduser (cram) succeeded"
+	else
+		echo "  testing command vadduser (cram) failed"
+		exit 1
+	fi
+	pass=$(sudo env - \
+		PATH=/bin:/usr/bin \
+		ASSIGNDIR=$sysconfdir/users \
+		SYSCONFDIR=$sysconfdir \
+		CONTROLDIR=$cntrldir \
+		vuserinfo -p $testuser2 | awk '{print $3}' | cut -c1-6)
+	if [ "$pass" = "{CRAM}" ] ; then
+		tcount=$(expr $tcount + 1)
+		echo "  testing command vadduser (cram format) succeeded"
+	else
+		echo "  testing command vadduser (cram format) failed"
+	fi
+}
+
 function create_scram_user()
 {
 	sudo env - \
@@ -809,13 +843,13 @@ function do_smtp_auth_login_swaks()
 				last_line=$(tail -1 $logdir/smtpd/current|grep "AUTH $i:")
 				if [ $? -eq 0 ] ; then
 					tcount=$(expr $tcount + 1)
-					printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s succeeded\n" "$i" "$str" "swaks"
+					printf "  testing mail  AUTH %-12s SMTP auth (%s) using swaks succeeded\n" "$i" "$str"
 				else
-					printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s failed\n"    "$i" "$str" "swaks"
+					printf "  testing mail  AUTH %-12s SMTP auth (%s) using swaks failed\n"    "$i" "$str"
 					exit 1
 				fi
 			else
-				echo "  testing mail    delivery in do_smtp_auth_login_swaks failed"
+				echo "  testing mail  delivery in do_smtp_auth_login_swaks failed"
 				exit 1
 			fi
 		done
@@ -833,6 +867,10 @@ function do_smtp_auth_login_swaks()
 
 function do_smtp_auth_qmail_remote()
 {
+	# domain   = $1
+	# user     = $2
+	# password = $3
+	# type     = $4
 	for j in 1 2
 	do
 		case $j in
@@ -857,7 +895,11 @@ function do_smtp_auth_qmail_remote()
 				pass=$3
 				;;
 				*)
-				pass=$(sudo setuidgid indimail envdir $servicedir/smtpd/variables vuserinfo -p $2 | awk '{print $3}')
+				if [ $4 -eq 1 ] ; then
+					pass=$(sudo setuidgid indimail envdir $servicedir/smtpd/variables vuserinfo -p $2 | awk '{print $3}')
+				else
+					pass=$3
+				fi
 				;;
 			esac
 			(
@@ -877,13 +919,14 @@ function do_smtp_auth_qmail_remote()
 				last_line=$(tail -1 $logdir/smtpd/current|grep "AUTH $i:")
 				if [ $? -eq 0 ] ; then
 					tcount=$(expr $tcount + 1)
-					printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s succeeded\n" "$i" "$str" "qmail-remote"
+					printf "  testing mail  AUTH %-12s SMTP auth (%s) using qmail-remote for %s succeeded\n" "$i" "$str" "$2"
 				else
-					printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s failed\n"    "$i" "$str" "qmail-remote"
+					printf "  testing mail  AUTH %-12s SMTP auth (%s) using qmail-remote for %s failed\n"    "$i" "$str" "$2"
 					exit 1
 				fi
 			else
-				echo "  testing mail    delivery in do_smtp_auth_qmail_remote failed"
+				echo "  testing mail  delivery in do_smtp_auth_qmail_remote failed"
+				less $logdir/qremote/qmail-remote.log
 				exit 1
 			fi
 		done
@@ -909,13 +952,13 @@ function do_smtp_auth_qmail_remote_scram()
 		last_line=$(tail -1 $logdir/smtpd/current|grep "AUTH $1:")
 		if [ $? -eq 0 ] ; then
 			tcount=$(expr $tcount + 1)
-			printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s (plaintext) succeeded\n" "$1" "$str" "qmail-remote"
+			printf "  testing mail  AUTH %-18s SMTP auth (%s) using qmail-remote (plaintext) succeeded\n" "$1" "$str"
 		else
-			printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s (plaintext) failed\n" "$1" "$str" "qmail-remote"
+			printf "  testing mail  AUTH %-18s SMTP auth (%s) using qmail-remote (plaintext) failed\n" "$1" "$str"
 			exit 1
 		fi
 	else
-		echo "  testing mail    delivery in do_smtp_auth_qmail_remote_scram failed"
+		echo "  testing mail  delivery in do_smtp_auth_qmail_remote_scram failed"
 		exit 1
 	fi
 	hexsalted=$(sudo setuidgid indimail envdir $servicedir/smtpd/variables vuserinfo -p $3 | cut -d: -f3)
@@ -937,13 +980,13 @@ function do_smtp_auth_qmail_remote_scram()
 		last_line=$(tail -1 $logdir/smtpd/current|grep "AUTH $1:")
 		if [ $? -eq 0 ] ; then
 			tcount=$(expr $tcount + 1)
-			printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s (hexsalted) succeeded\n" "$1" "$str" "qmail-remote"
+			printf "  testing mail  AUTH %-18s SMTP auth (%s) using qmail-remote (hexsalted) succeeded\n" "$1" "$str"
 		else
-			printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s (hexsalted) failed\n" "$1" "$str" "qmail-remote"
+			printf "  testing mail  AUTH %-18s SMTP auth (%s) using qmail-remote (hexsalted) failed\n" "$1" "$str"
 			exit 1
 		fi
 	else
-		echo "  testing mail    delivery in do_smtp_auth_qmail_remote_scram failed"
+		echo "  testing mail  delivery in do_smtp_auth_qmail_remote_scram failed"
 		exit 1
 	fi
 }
@@ -962,9 +1005,9 @@ function do_gsasl_test()
 		--mechanism "$1" --smtp --connect localhost:2025 >> $logdir/gsasl/gsasl.log 2>&1
 	if [ $? -eq 0 ] ; then
 		tcount=$(expr $tcount + 1)
-		printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s succeeded\n" "$1" "$str" "gsasl"
+		printf "  testing mail  AUTH %-18s SMTP auth (%s) using gsasl succeeded\n" "$1" "$str"
 	else
-		printf "  testing mail    AUTH %-18s SMTP authentication (%s) using %-12s failed\n" "$1" "$str" "gsasl"
+		printf "  testing mail  AUTH %-18s SMTP auth (%s) using gsasl failed\n" "$1" "$str"
 		exit 1
 	fi
 }
@@ -1069,9 +1112,9 @@ function test_pop3()
 	tcpclient  -vDHR 0 1100 /tmp/qmail-test/tcpclient.pop3 2> $logdir/pop3d/pop3d.log
 	if [ $? -eq 0 ] ; then
 		tcount=$(expr $tcount + 1)
-		printf "  testing mail    POP3  login and mail retrieval (%s) succeeded\n" "$str"
+		printf "  testing mail  POP3  login and mail retrieval (%s) succeeded\n" "$str"
 	else
-		printf "  testing mail    POP3  login and mail retrieval (%s) failed\n" "$str"
+		printf "  testing mail  POP3  login and mail retrieval (%s) failed\n" "$str"
 		exit 1
 	fi
 	swaks -S --to testuser01@$domain3 --from $testuser1 --server ::1 --port 2025 >/dev/null 2>&1
@@ -1090,9 +1133,9 @@ function test_pop3()
 	tcpclient -n "" -vDHR 0 9950 /tmp/qmail-test/tcpclient.pop3 2> $logdir/pop3d-ssl/pop3d-ssl.log
 	if [ $? -eq 0 ] ; then
 		tcount=$(expr $tcount + 1)
-		printf "  testing mail    POP3S login and mail retrieval (%s) succeeded\n" "$str"
+		printf "  testing mail  POP3S login and mail retrieval (%s) succeeded\n" "$str"
 	else
-		printf "  testing mail    POP3S login and mail retrieval (%s) failed\n" "$str"
+		printf "  testing mail  POP3S login and mail retrieval (%s) failed\n" "$str"
 		exit 1
 	fi
 	swaks -S --to testuser01@$domain3 --from $testuser1 --server ::1 --port 2025 >/dev/null 2>&1
@@ -1171,9 +1214,9 @@ function test_imap()
 	tcpclient  -vDHR 0 1430 /tmp/qmail-test/tcpclient.imap 2>$logdir/imapd/imapd.log
 	if [ $? -eq 0 ] ; then
 		tcount=$(expr $tcount + 1)
-		printf "  testing mail    IMAP  login and mail retrieval (%s) succeeded\n" "$str"
+		printf "  testing mail  IMAP  login and mail retrieval (%s) succeeded\n" "$str"
 	else
-		printf "  testing mail    IMAP  login and mail retrieval (%s) failed\n" "$str"
+		printf "  testing mail  IMAP  login and mail retrieval (%s) failed\n" "$str"
 		less $logdir/imapd/imapd.log
 		exit 1
 	fi
@@ -1201,9 +1244,9 @@ function test_imap()
 	tcpclient -n "" -vDHR 0 9930 /tmp/qmail-test/tcpclient.imap 2> $logdir/imapd-ssl/imapd-ssl.log
 	if [ $? -eq 0 ] ; then
 		tcount=$(expr $tcount + 1)
-		printf "  testing mail    IMAPS login and mail retrieval (%s) succeeded\n" "$str"
+		printf "  testing mail  IMAPS login and mail retrieval (%s) succeeded\n" "$str"
 	else
-		printf "  testing mail    IMAPS login and mail retrieval (%s) failed\n" "$str"
+		printf "  testing mail  IMAPS login and mail retrieval (%s) failed\n" "$str"
 		exit 1
 	fi
 	swaks -S --to testuser01@$domain3 --from $testuser1 --server ::1 --port 2025 >/dev/null 2>&1
@@ -1485,13 +1528,17 @@ create_domain $domain1 pass
 do_vdominfo
 do_dbinfo
 create_plain_user $testuser1 $password2
+create_cram_user  $testuser2 $password3
 sudo svc -2 $servicedir/inlookup.infifo
 
 do_inquerytest $testuser1
 
 do_smtp_auth_login_swaks $testuser1 $password2
 
-do_smtp_auth_qmail_remote $domain1 $testuser1 $password2
+do_smtp_auth_qmail_remote $domain1 $testuser1 $password2 1
+> $servicedir/smtpd/variables/ENABLE_CRAM
+do_smtp_auth_qmail_remote $domain1 $testuser2 $password3 2
+delete_user $testuser2
 
 change_password $testuser1 $password1
 do_vmoduser $testuser1
@@ -1568,8 +1615,8 @@ tcount=$(expr $tcount + 3)
 printf "  testing command tcpserver non-encrypted succeeded\n"
 printf "  testing command tcpclient non-encrypted succeeded\n"
 printf "  testing command tcpclient encrypted     succeeded\n"
-create_scram_user SCRAM-SHA-1   $testuser1 $password1 MD5 1
-create_scram_user SCRAM-SHA-256 $testuser2 $password2 MD5 1
+create_scram_user SCRAM-SHA-1   $testuser1 $password1 SHA-512 1
+create_scram_user SCRAM-SHA-256 $testuser2 $password2 SHA-512 1
 echo
 do_valias $testuser1 $testuser2
 echo
@@ -1588,5 +1635,8 @@ echo "All $tcount tests succeeded"
 exit 0
 
 #
-# $Log: $
+# $Log: testindimail-virtual,v $
+# Revision 1.1  2023-07-15 00:14:58+05:30  Cprogrammer
+# Initial revision
+#
 #

--- a/indimail-x/userinfo.c
+++ b/indimail-x/userinfo.c
@@ -1,38 +1,5 @@
 /*
- * $Log: userinfo.c,v $
- * Revision 1.11  2023-03-20 10:20:32+05:30  Cprogrammer
- * standardize getln handling
- *
- * Revision 1.10  2023-01-22 10:40:03+05:30  Cprogrammer
- * replaced qprintf with subprintf
- *
- * Revision 1.9  2022-08-28 12:03:43+05:30  Cprogrammer
- * fixed display string for DES/un-encrypted password
- *
- * Revision 1.8  2022-08-04 14:42:22+05:30  Cprogrammer
- * display scram password if existing
- *
- * Revision 1.7  2021-08-21 12:52:33+05:30  Cprogrammer
- * moved no_of_days.h to libqmail
- *
- * Revision 1.6  2021-07-22 15:17:31+05:30  Cprogrammer
- * conditional define of _XOPEN_SOURCE
- *
- * Revision 1.5  2020-10-13 18:35:14+05:30  Cprogrammer
- * initialize struct tm for strptime() value too big error
- *
- * Revision 1.4  2020-04-01 18:58:19+05:30  Cprogrammer
- * moved authentication functions to libqmail
- *
- * Revision 1.3  2019-06-07 16:10:48+05:30  mbhangui
- * fix for missing mysql_get_option() in new versions of libmariadb
- *
- * Revision 1.2  2019-04-17 17:54:35+05:30  Cprogrammer
- * display db server info only for root
- *
- * Revision 1.1  2019-04-14 18:30:56+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: userinfo.c,v 1.12 2023-07-15 00:23:45+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -95,7 +62,7 @@
 #include "userinfo.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: userinfo.c,v 1.11 2023-03-20 10:20:32+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: userinfo.c,v 1.12 2023-07-15 00:23:45+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 extern char *strptime(const char *, const char *, struct tm *);
@@ -614,3 +581,43 @@ userinfo(Email, User, Domain, DisplayName, DisplayPasswd, DisplayUid, DisplayGid
 	flush("userinfo");
 	return (0);
 }
+
+/*
+ * $Log: userinfo.c,v $
+ * Revision 1.12  2023-07-15 00:23:45+05:30  Cprogrammer
+ * Display clear text passwords for CRAM with label CRAM
+ *
+ * Revision 1.11  2023-03-20 10:20:32+05:30  Cprogrammer
+ * standardize getln handling
+ *
+ * Revision 1.10  2023-01-22 10:40:03+05:30  Cprogrammer
+ * replaced qprintf with subprintf
+ *
+ * Revision 1.9  2022-08-28 12:03:43+05:30  Cprogrammer
+ * fixed display string for DES/un-encrypted password
+ *
+ * Revision 1.8  2022-08-04 14:42:22+05:30  Cprogrammer
+ * display scram password if existing
+ *
+ * Revision 1.7  2021-08-21 12:52:33+05:30  Cprogrammer
+ * moved no_of_days.h to libqmail
+ *
+ * Revision 1.6  2021-07-22 15:17:31+05:30  Cprogrammer
+ * conditional define of _XOPEN_SOURCE
+ *
+ * Revision 1.5  2020-10-13 18:35:14+05:30  Cprogrammer
+ * initialize struct tm for strptime() value too big error
+ *
+ * Revision 1.4  2020-04-01 18:58:19+05:30  Cprogrammer
+ * moved authentication functions to libqmail
+ *
+ * Revision 1.3  2019-06-07 16:10:48+05:30  mbhangui
+ * fix for missing mysql_get_option() in new versions of libmariadb
+ *
+ * Revision 1.2  2019-04-17 17:54:35+05:30  Cprogrammer
+ * display db server info only for root
+ *
+ * Revision 1.1  2019-04-14 18:30:56+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/userinfo.c
+++ b/indimail-x/userinfo.c
@@ -287,6 +287,9 @@ userinfo(Email, User, Domain, DisplayName, DisplayPasswd, DisplayUid, DisplayGid
 	if (!str_diffn(mypw->pw_passwd, "{SCRAM-SHA-256}", 15))
 		passwd_hash = "SCRAM-SHA-256";
 	else
+	if (!str_diffn(mypw->pw_passwd, "{CRAM}", 6))
+		passwd_hash = "CRAM";
+	else
 	if (mypw->pw_passwd[0] == '$' && mypw->pw_passwd[2] == '$') {
 		switch(mypw->pw_passwd[1])
 		{

--- a/indimail-x/vadddomain.9
+++ b/indimail-x/vadddomain.9
@@ -14,8 +14,6 @@ vadddomain \- Create a virtual domain
 ]
 
 .SH DESCRIPTION
-
-.PP
 .B vadddomain
 adds a new virtual domain. It creates the necessary \fBqmail\fR control
 files and a \fB.qmail-default\fR containing delivery instructions.
@@ -60,7 +58,6 @@ passed the same command line arguments as passed to \fBvadddomain\fR. The
 steps have been successful.
 
 .SH OPTIONS
-.PP
 \fIvirtual_domain\fR is mandatory. Rest are optional. If
 \fIpostmaster_password\fR is not given, \fBvadddomain\fR will prompt for
 the password.
@@ -158,7 +155,7 @@ command line.
 
 .TP
 \fB\-h\fR \fIhash\fR
-Specifiy hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
+Specify hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
 the id in \fI/etc/shadow\fR. See \fBincrypt\fR(1).
 .TS
 l l.
@@ -187,14 +184,18 @@ PASSWORD_HASH Value	Description
 .fi
 .RE
 
-.TP
+.TP 3
 \fB\-m\fR \fIscram\fR
-Specifiy scram method which is one of SCRAM-SHA-1, SCRAM-SHA-256
+Sets the CRAM or SCRAM method for encryption. This will set SCRAM password in
+the \fIscram\fR field in indimail/indibak tables. For CRAM method, it will
+set clear text password when -C option is specified.
 .RS
 .nf
 .ta 5c 10c
-SCRAM method	Description
--------------	-----------
+CRAM/SCRAM method	Description
+-----------------	-----------
+CRAM	Sets clear text password suitable for any
+	CRAM method (CRAM-MD5, CRAM-SHA1, ...)
 SCRAM-SHA-1	SHA1 encryption suitable for SCRAM-SHA-1.
 SCRAM-SHA-256	SHA256 encryption suitable for SCRAM-SHA-256.
 .fi

--- a/indimail-x/vadduser.9
+++ b/indimail-x/vadduser.9
@@ -107,10 +107,10 @@ Structure Layout for all users can be regenerated using the program
 \fBvreorg(8)\fR.
 
 .SH OPTIONS
-.PP
 .TP 3
 \fB\-v\fR
 Set verbose mode.
+
 .TP
 \fB\-e\fR
 Set the encrypted Password field
@@ -119,13 +119,15 @@ password provided on the command line. This option sets the encrypted
 password field exactly as given on the command line without any encryption.
 It expects you to give a standard encrypted password or you can use
 this to set plaintext/salted password for CRAM authentication.
+
 .TP
 \fB\-r\fR
 Generates Random Password of length \fIlen\fR. Need not give password on
 command line.
+
 .TP
 \fB\-h\fR \fIhash\fR
-Specifiy hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
+Specify hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
 the id in \fI/etc/shadow\fR. See \fBincrypt\fR(1).
 .TS
 l l.
@@ -154,19 +156,24 @@ PASSWORD_HASH Value	Description
 .fi
 .RE
 
-.TP
+.TP 3
 \fB\-m\fR \fIscram\fR
-Specifiy scram method which is one of SCRAM-SHA-1, SCRAM-SHA-256
+Sets the CRAM or SCRAM method for encryption. This will set SCRAM password in
+the \fIscram\fR field in indimail/indibak tables. For CRAM method, it will
+set clear text password when -C option is specified.
 .RS
 .nf
 .ta 5c 10c
-SCRAM method	Description
--------------	-----------
+CRAM/SCRAM method	Description
+-----------------	-----------
+CRAM	Sets clear text password suitable for any
+	CRAM method (CRAM-MD5, CRAM-SHA1, ...)
 SCRAM-SHA-1	SHA1 encryption suitable for SCRAM-SHA-1.
 SCRAM-SHA-256	SHA256 encryption suitable for SCRAM-SHA-256.
 .fi
 .tc
 .RE
+
 .TP
 \fB\-C\fR
 Sets up authentication suitable for CRAM-MD5, CRAM-SHA1, CRAM-SHA224,
@@ -175,34 +182,41 @@ This works by storing the clear text credentials in the database. if the
 \-\fIm\fR option is selected, this will additionally store a hex-encoded
 salted password for SCRAM methods, which can be used instead of clear text
 passwords by clients (for SCRAM authentication).
+
 .TP 3
 \fB\-S\fR \fIsalt\fR
 Specify a base64 encoded salt to be used when generating SCRAM password. If
 not specified, this will be generated using libsodium/gsasl. Here base64
 implies characters [0-9], [a-z], [A-Z] and the two characters [./].
+
 .TP
 \fB\-I\fR \fIiteration\fR
 Specify the iteration count to be used when generating SCRAM password. The
 default is 4096.
+
 .TP
 \fB\-c\fR \fIComment\fR
 Set Comment (Sets the gecos comment field)
+
 .TP
 \fB\-d\fR
 Create the directory for the user. If this option is not given, the home
 directory is not created. It gets created when the user logs in either
 through IMAP4 or POP3 protocol.
+
 .TP
 \fB\-B\fR \fIbase_path\fR
 Set the base path for the user's home directory. This overrides the base
 path defined in the domain's directory defined in
 \fI@indimaildir@/users/assign\fR file, the environment variable
 \fBBASE_PATH\fR and the default base path \fI/home/mail\fR.
+
 .TP
 \fB\-b\fR
 Balances users across filesystems listed in fstab table as they are
 created. This option should be used if vfstab (with -b option) is enabled
 in cron. This option overrides the \fB\-B\fR option.
+
 .TP
 \fB\-l\fR users_per_level
 By default, \fBvadduser\fR uses an adaptive directory structure based on a
@@ -211,6 +225,7 @@ table dir-control which is automatically managed by \fBvadduser(1)\fR,
 Maildir directories across multiple directories and sub directories so that
 there are never more than 100 user directories in a single directory. Use
 this option to change the default compile time value of 100 users per directory.
+
 .TP
 \fB\-q\fR [\fIquota in bytes\fR]
 Set the hard quota limit for the user. If not supplied then the default
@@ -223,19 +238,23 @@ limits apply. Also, this option will not be allowed if permission for
 creating quota is disabled in domain limits.
 
 You can use the suffix k/K, m/M, g/G to specify quota in Kb, Mb or Gb.
+
 .TP
 \fB\-H\fR \fIhostid\fR
 For a clustered domain, this option can be used to create the user on a
 specific host having \fIhostid\fR as the hostid.
+
 .TP
 \fB\-M\fR \fImdahost\fR
 For a clustered domain, this option can be used to create the user on a
 specific cluster having Mail Delivery Host as \fImdahost\fR.
+
 .TP
 \fIaddress\fR
 The new email address of the user. Requires the domain name as well as the
 user name. For example: user@domain.com. If the domain name is not
 specified the user is added to the default domain.
+
 .TP
 \fIpassword\fR
 Set the password for the user. If the password is not supplied on the

--- a/indimail-x/vchkpass.c
+++ b/indimail-x/vchkpass.c
@@ -1,5 +1,5 @@
 /*
- * $Id: $
+ * $Id: vchkpass.c,v 1.20 2023-07-15 00:30:17+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -44,7 +44,7 @@
 #include "runcmmd.h"
 
 #ifndef lint
-static char     sccsid[] = "$Id: vchkpass.c,v 1.19 2023-06-17 23:47:50+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: vchkpass.c,v 1.20 2023-07-15 00:30:17+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #ifdef AUTH_SIZE
@@ -302,7 +302,7 @@ main(int argc, char **argv)
 	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
 		pw->pw_passwd += 6;
 		cleartxt = pw->pw_passwd;
-		i = str_rchr(pw->pw_passwd, ':');
+		i = str_rchr(pw->pw_passwd, ',');
 		if (pw->pw_passwd[i]) {
 			pw->pw_passwd[i] = 0;
 			pw->pw_passwd += (i + 1);
@@ -431,6 +431,9 @@ main(int argc, char **argv)
 
 /*
  * $Log: vchkpass.c,v $
+ * Revision 1.20  2023-07-15 00:30:17+05:30  Cprogrammer
+ * authenticate using CRAM when password field starts with {CRAM}
+ *
  * Revision 1.19  2023-06-17 23:47:50+05:30  Cprogrammer
  * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
  *

--- a/indimail-x/vchkpass.c
+++ b/indimail-x/vchkpass.c
@@ -1,62 +1,5 @@
 /*
- * $Log: vchkpass.c,v $
- * Revision 1.19  2023-06-17 23:47:50+05:30  Cprogrammer
- * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
- *
- * Revision 1.18  2023-01-22 10:40:03+05:30  Cprogrammer
- * replaced qprintf with subprintf
- *
- * Revision 1.17  2022-11-05 21:13:57+05:30  Cprogrammer
- * use ENABLE_CRAM to allow use of pw_passwd field of indimail, indibak for authentication
- *
- * Revision 1.16  2022-10-29 23:10:52+05:30  Cprogrammer
- * fixed display of auth method in logs
- *
- * Revision 1.15  2022-08-27 12:04:41+05:30  Cprogrammer
- * fixed logic for fetching clear txt password for cram methods
- *
- * Revision 1.14  2022-08-25 18:03:04+05:30  Cprogrammer
- * fetch clear text passwords for CRAM authentication
- *
- * Revision 1.13  2022-08-23 08:21:44+05:30  Cprogrammer
- * display AUTH method as a string instead of a number
- *
- * Revision 1.12  2022-08-04 14:43:02+05:30  Cprogrammer
- * authenticate using SCRAM salted password
- *
- * Revision 1.11  2021-09-11 13:41:27+05:30  Cprogrammer
- * fixed typo in error statement
- *
- * Revision 1.10  2021-07-22 15:17:34+05:30  Cprogrammer
- * conditional define of _XOPEN_SOURCE
- *
- * Revision 1.9  2021-01-27 18:46:10+05:30  Cprogrammer
- * renamed use_dovecot to native_checkpassword
- *
- * Revision 1.8  2021-01-27 13:23:25+05:30  Cprogrammer
- * use use_dovecot variable instead of env_get() twice
- *
- * Revision 1.7  2021-01-26 14:17:22+05:30  Cprogrammer
- * set HOME, userdb_uid, userdb_gid, EXTRA env variables for dovecot
- *
- * Revision 1.6  2021-01-26 13:45:03+05:30  Cprogrammer
- * modified to support dovecot checkpassword authentication
- *
- * Revision 1.5  2020-09-28 13:28:28+05:30  Cprogrammer
- * added pid in debug statements
- *
- * Revision 1.4  2020-09-28 12:49:53+05:30  Cprogrammer
- * print authmodule name in error logs/debug statements
- *
- * Revision 1.3  2020-04-01 18:58:32+05:30  Cprogrammer
- * moved authentication functions to libqmail
- *
- * Revision 1.2  2019-07-10 12:58:04+05:30  Cprogrammer
- * print more error information in print_error
- *
- * Revision 1.1  2019-04-18 08:14:23+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -306,7 +249,7 @@ main(int argc, char **argv)
 	if (pw->pw_gid & NO_RELAY)
 		norelay = 1;
 	crypt_pass = (char *) NULL;
-		/*- we have three situation
+		/*- we have three situations
 		 * 1. We have set SCRAM method in (-m option in vadddomain, vadduser, vpasswd,
 		 *    vmoduser, vgroup)
 		 *    a. For CRAM methods we use the clear text passwords in variable cleartxt
@@ -315,12 +258,12 @@ main(int argc, char **argv)
 		 * 2. We don't have SCRAM passwords
 		 *    a. we use crypted password in variable crypt_pass for LOGIN, PLAIN.
 		 *       we expect a crypted password using crypt(3) is stored in pw_password field
-		 *    b. we use crypted password in variable crypt_pass for CRAM methods (-e option in
+		 *    b. we use cleartxt password in variable crypt_pass for CRAM methods (-e option in
 		 *       vadddomain, vadduser, vpasswd, vmoduser, vgroup)
 		 *       but it is expected that the pw_passwd field has the clear text passwords stored for
 		 *       CRAM to succeed.
-		 *    c. b. implies that the crypted password can be supplied by the client for password
-		 *       when using CRAM
+		 * 3. 2b implies that the crypted password can be supplied by the client for password
+		 *       when using CRAM. We allow this if enable_cram is set by setting ENABLE_CRAM
 		 */
 	if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-1}", 13) || !str_diffn(pw->pw_passwd, "{SCRAM-SHA-256}", 15)) {
 		i = get_scram_secrets(pw->pw_passwd, 0, 0, 0, 0, 0, 0, &cleartxt, &crypt_pass);
@@ -346,14 +289,39 @@ main(int argc, char **argv)
 				if (enable_cram)
 					pass = crypt_pass;
 				else
-					pass = (auth_method > 2 && auth_method < 11) ? NULL : crypt_pass;
+					pass = (auth_method >= AUTH_CRAM_MD5 && auth_method <= AUTH_DIGEST_MD5) ? NULL : crypt_pass;
 				break;
 			}
 		} else {
 			if (enable_cram)
 				pass = crypt_pass;
 			else
-				pass = (auth_method > 2 && auth_method < 11) ? NULL : crypt_pass;
+				pass = (auth_method >= AUTH_CRAM_MD5 && auth_method <= AUTH_DIGEST_MD5) ? NULL : crypt_pass;
+		}
+	} else
+	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
+		pw->pw_passwd += 6;
+		cleartxt = pw->pw_passwd;
+		i = str_rchr(pw->pw_passwd, ':');
+		if (pw->pw_passwd[i]) {
+			pw->pw_passwd[i] = 0;
+			pw->pw_passwd += (i + 1);
+		}
+		switch (auth_method)
+		{
+		case AUTH_CRAM_MD5:
+		case AUTH_CRAM_SHA1:
+		case AUTH_CRAM_SHA224:
+		case AUTH_CRAM_SHA256:
+		case AUTH_CRAM_SHA384:
+		case AUTH_CRAM_SHA512:
+		case AUTH_CRAM_RIPEMD:
+		case AUTH_DIGEST_MD5:
+			pass = cleartxt;
+			break;
+		default:
+			pass = crypt_pass = pw->pw_passwd;
+			break;
 		}
 	} else {
 		i = 0;
@@ -361,7 +329,7 @@ main(int argc, char **argv)
 		if (enable_cram)
 			pass = crypt_pass;
 		else
-			pass = (auth_method > 2 && auth_method < 11) ? NULL : crypt_pass;
+			pass = (auth_method >= AUTH_CRAM_MD5 && auth_method <= AUTH_DIGEST_MD5) ? NULL : crypt_pass;
 	}
 	module_pid[fmt_ulong(module_pid, getpid())] = 0;
 	if ((ptr = env_get("DEBUG_LOGIN")) && *ptr > '0') {
@@ -384,7 +352,7 @@ main(int argc, char **argv)
 	/*- force pw_comp to use crypt instead of in_crypt */
 	if (!env_get("PASSWORD_HASH") && !env_put2("PASSWORD_HASH", "0"))
 		die_nomem();
-	if (pw_comp((unsigned char *) ologin, (unsigned char *) pass,
+	if (!pass || !*pass || pw_comp((unsigned char *) ologin, (unsigned char *) pass,
 				(unsigned char *) (*response ? challenge : 0),
 				(unsigned char *) (*response ? response : challenge), auth_method)) {
 		native_checkpassword ? _exit (1) : pipe_exec(argv, authstr, offset);
@@ -460,3 +428,64 @@ main(int argc, char **argv)
 	/*- Not reached */
 	return(0);
 }
+
+/*
+ * $Log: vchkpass.c,v $
+ * Revision 1.19  2023-06-17 23:47:50+05:30  Cprogrammer
+ * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
+ *
+ * Revision 1.18  2023-01-22 10:40:03+05:30  Cprogrammer
+ * replaced qprintf with subprintf
+ *
+ * Revision 1.17  2022-11-05 21:13:57+05:30  Cprogrammer
+ * use ENABLE_CRAM to allow use of pw_passwd field of indimail, indibak for authentication
+ *
+ * Revision 1.16  2022-10-29 23:10:52+05:30  Cprogrammer
+ * fixed display of auth method in logs
+ *
+ * Revision 1.15  2022-08-27 12:04:41+05:30  Cprogrammer
+ * fixed logic for fetching clear txt password for cram methods
+ *
+ * Revision 1.14  2022-08-25 18:03:04+05:30  Cprogrammer
+ * fetch clear text passwords for CRAM authentication
+ *
+ * Revision 1.13  2022-08-23 08:21:44+05:30  Cprogrammer
+ * display AUTH method as a string instead of a number
+ *
+ * Revision 1.12  2022-08-04 14:43:02+05:30  Cprogrammer
+ * authenticate using SCRAM salted password
+ *
+ * Revision 1.11  2021-09-11 13:41:27+05:30  Cprogrammer
+ * fixed typo in error statement
+ *
+ * Revision 1.10  2021-07-22 15:17:34+05:30  Cprogrammer
+ * conditional define of _XOPEN_SOURCE
+ *
+ * Revision 1.9  2021-01-27 18:46:10+05:30  Cprogrammer
+ * renamed use_dovecot to native_checkpassword
+ *
+ * Revision 1.8  2021-01-27 13:23:25+05:30  Cprogrammer
+ * use use_dovecot variable instead of env_get() twice
+ *
+ * Revision 1.7  2021-01-26 14:17:22+05:30  Cprogrammer
+ * set HOME, userdb_uid, userdb_gid, EXTRA env variables for dovecot
+ *
+ * Revision 1.6  2021-01-26 13:45:03+05:30  Cprogrammer
+ * modified to support dovecot checkpassword authentication
+ *
+ * Revision 1.5  2020-09-28 13:28:28+05:30  Cprogrammer
+ * added pid in debug statements
+ *
+ * Revision 1.4  2020-09-28 12:49:53+05:30  Cprogrammer
+ * print authmodule name in error logs/debug statements
+ *
+ * Revision 1.3  2020-04-01 18:58:32+05:30  Cprogrammer
+ * moved authentication functions to libqmail
+ *
+ * Revision 1.2  2019-07-10 12:58:04+05:30  Cprogrammer
+ * print more error information in print_error
+ *
+ * Revision 1.1  2019-04-18 08:14:23+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/vgroup.1
+++ b/indimail-x/vgroup.1
@@ -3,10 +3,11 @@
 vgroup \- create distribution groups for set of users in a virtual domain
 
 .SH SYNOPSYS
-.PP
+.nf
 \fBvgroup\fR \fB\-a\fR [\fB\-n\fR] [\fB\-c\fR][\fBq\fR] [\fB\-v\fR] \fIgroupAddress\fR [\fIpassword\fR]
-.PP
-\fBvgroup\fR [\fB\-i\fR \fIaliasLine\fR] [\fB\-d\fR \fIaliasLine\fR] [\fB\-u\fR \fInewaliasLine\fR \fB\-o\fR \fIoldaliasLine\fR] [\fB\-v\fR] \fIgroupAddress\fR
+\fBvgroup\fR [\fB\-i\fR \fIaliasLine\fR] [\fB\-d\fR \fIaliasLine\fR]
+  [\fB\-u\fR \fInewaliasLine\fR \fB\-o\fR \fIoldaliasLine\fR] [\fB\-v\fR] \fIgroupAddress\fR
+.fi
 
 .SH DESCRIPTION
 \fBvgroup\fR implements groups functionality in IndiMail. It is a utility to add groups.
@@ -33,6 +34,7 @@ Common Options
 .TP 3
 \fB\-v\fR
 Sets verbose mode while vgroup is operating
+
 .TP
 \fIgroupAddress\fR
 Email address for the group.
@@ -47,13 +49,15 @@ password provided on the command line. This option sets the encrypted
 password field exactly as given on the command line without any encryption.
 It expects you to give a standard encrypted password or you can use
 this to set plaintext/salted password for CRAM authentication.
+
 .TP
 \fB\-r\fR \fIlen\fR
 Generates Random Password of length \fIlen\fR. Need not give password on
 command line.
+
 .TP
 \fB\-h\fR \fIhash\fR
-Specifiy hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
+Specify hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
 the id in \fI/etc/shadow\fR. See \fBincrypt\fR(1).
 .TS
 l l.
@@ -64,18 +68,42 @@ MD5     1  MD5 encryption (shouldn't be used)
 SHA-256 5  SHA256 encryption
 SHA-512 6  SHA512 encryption
 .TE
+
+You can also set the environment variable \fBPASSWORD_HASH\fR to set the
+encryption method. The -h argument overrides the environment variable
+\fBPASSWORD_HASH\fR. The value of \fBPASSWORD_HASH\fR environment variable
+identifies the encryption method used and this then determines how the rest
+of the password string is interpreted. The following values of
+\fBPASSWORD_HASH\fR are supported:
+
+.nf
+.ta 5c 10c
+PASSWORD_HASH Value	Description
+0	DES encryption (shouldn't be used)
+1	MD5 encryption (shouldn't be used)
+2	SHA256 encryption
+3	SHA512 encryption
+.fi
+.RE
+
+.TP 3
 \fB\-m\fR \fIscram\fR
-Specifiy scram method which is one of SCRAM-SHA-1, SCRAM-SHA-256
+Sets the CRAM or SCRAM method for encryption. This will set SCRAM password in
+the \fIscram\fR field in indimail/indibak tables. For CRAM method, it will
+set clear text password when -C option is specified.
 .RS
 .nf
 .ta 5c 10c
-SCRAM method	Description
--------------	-----------
+CRAM/SCRAM method	Description
+-----------------	-----------
+CRAM	Sets clear text password suitable for any
+	CRAM method (CRAM-MD5, CRAM-SHA1, ...)
 SCRAM-SHA-1	SHA1 encryption suitable for SCRAM-SHA-1.
 SCRAM-SHA-256	SHA256 encryption suitable for SCRAM-SHA-256.
 .fi
 .tc
 .RE
+
 .TP
 \fB\-C\fR
 Sets up authentication suitable for CRAM-MD5, CRAM-SHA1, CRAM-SHA224,
@@ -84,29 +112,36 @@ This works by storing the clear text credentials in the database. if the
 \-\fIm\fR option is selected, this will additionally store a hex-encoded
 salted password for SCRAM methods, which can be used instead of clear text
 passwords by clients (for SCRAM authentication).
+
 .TP 3
 \fB\-S\fR \fIsalt\fR
 Specify a base64 encoded salt to be used when generating SCRAM password. If
 not specified, this will be generated using libsodium/gsasl. Here base64
 implies characters [0-9], [a-z], [A-Z] and the two characters [./].
+
 .TP
 \fB\-I\fR \fIiteration\fR
 Specify the iteration count to be used when generating SCRAM password. The
 default is 4096.
+
 .TP
 \fIpasswd\fR
 Passwd for the user. If not given, user will be prompted.
+
 .TP
 \fB\-a\fR
 Add a new group.
+
 .TP
 \fB\-H\fR \fIhostid\fR
 For a clustered domain, this option can be used to create the user on a specific host having
 \fIhostid\fR as the hostid.
+
 .TP
 \fB\-M\fR \fImdahost\fR
 For a clustered domain, this option can be used to create the user on a specific cluster
 having Mail Delivery Host as \fImdahost\fR.
+
 .TP
 \fB\-c\fR
 Comment field (gecos) for the group account. Internally the comment starts with the
@@ -114,10 +149,12 @@ word 'IndiGroup'. This will be shown if you use the command vuserinfo on the gro
 It is advisable not to change this by external programs such as vmoduser. IndiMail figures
 out difference between a normal email account and a group account by checking if gecos
 field starts with the word 'IndiGroup'.
+
 .TP
 \fB\-q\fR
 Sets the Quota for the group. This should be set in case the group will also function as a
 normal user and receive mails.
+
 .TP
 \fB\-n\fR
 Ignore requirement of groupAddress to be a local address on the node where vgroup is
@@ -135,9 +172,11 @@ See \fBdot-qmail(5)\fR for more details.
  2. Maildir      - copy mails to a Maildir with path \fIMaildir\fR
  3. | Command    - pipe the mail through command \fICommand\fR
 .EE
+
 .TP
 \fB\-d\fR \fIaliasLine\fR
 delete aliasLine from the group. See valias for more details
+
 .TP
 \fB\-u\fR \fInewaliasLine\fR \fB\-o\fR \fIoldaliasLine\fR
 Modify oldaliasLine to newaliasLine alias in the group. See valias for more details

--- a/indimail-x/vmoduser.9
+++ b/indimail-x/vmoduser.9
@@ -71,7 +71,7 @@ field in indimail/indibak tables.
 
 .TP 3
 \fB\-h\fR \fIhash\fR
-Specifiy hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
+Specify hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
 the id in \fI/etc/shadow\fR. See \fBincrypt\fR(1).
 .TS
 l l.
@@ -102,12 +102,16 @@ PASSWORD_HASH Value	Description
 
 .TP 3
 \fB\-m\fR \fISCRAM_method\fR
-Sets the SCRAM method for encryption. This will set SCRAM password in the
-\fIscram\fR field in indimail/indibak tables.
+Sets the CRAM or SCRAM method for encryption. This will set SCRAM password in
+the \fIscram\fR field in indimail/indibak tables. For CRAM method, it will
+set clear text password when -C option is specified.
 
 .nf
 .ta 5c 10c
-SCRAM method	Value
+CRAM/SCRAM method	Description
+-----------------	-----------
+CRAM	Sets clear text password suitable for any
+	CRAM method (CRAM-MD5, CRAM-SHA1, ...)
 SCRAM-SHA-1	SHA1 encryption suitable for SCRAM-SHA-1.
 SCRAM-SHA-256	SHA256 encryption suitable for SCRAM-SHA-256.
 .fi

--- a/indimail-x/vmoduser.c
+++ b/indimail-x/vmoduser.c
@@ -1,58 +1,5 @@
 /*
- * $Log: vmoduser.c,v $
- * Revision 1.17  2023-03-23 22:20:51+05:30  Cprogrammer
- * removed incorrect call to vdeldomain
- *
- * Revision 1.16  2023-03-22 10:43:02+05:30  Cprogrammer
- * run POST_HANDLE program (if set) with domain user uid/gid
- *
- * Revision 1.15  2023-01-22 10:40:03+05:30  Cprogrammer
- * replaced qprintf with subprintf
- *
- * Revision 1.14  2022-11-08 17:17:56+05:30  Cprogrammer
- * removed compiler warning for unused variable
- *
- * Revision 1.13  2022-11-02 12:45:15+05:30  Cprogrammer
- * set usage string depeding on gsasl availability
- *
- * Revision 1.12  2022-10-20 11:59:07+05:30  Cprogrammer
- * converted function prototype to ansic
- *
- * Revision 1.11  2022-09-14 13:41:26+05:30  Cprogrammer
- * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
- *
- * Revision 1.10  2022-08-28 15:11:23+05:30  Cprogrammer
- * fix compilation error for non gsasl build
- *
- * Revision 1.9  2022-08-25 18:07:49+05:30  Cprogrammer
- * Make password compatible with CRAM and SCRAM
- * 1. store hex-encoded salted password for setting GSASL_SCRAM_SALTED_PASSWORD property in libgsasl
- * 2. store clear text password for CRAM authentication methods
- *
- * Revision 1.8  2022-08-24 18:35:17+05:30  Cprogrammer
- * made setting hash method and scram method independent
- *
- * Revision 1.7  2022-08-07 20:41:18+05:30  Cprogrammer
- * check return value of gsasl_mkpasswd() function
- *
- * Revision 1.6  2022-08-07 13:06:42+05:30  Cprogrammer
- * added option to set scram password
- *
- * Revision 1.5  2022-08-05 21:20:58+05:30  Cprogrammer
- * reversed encrypt_flag setting for mkpasswd() change in encrypt_flag
- *
- * Revision 1.4  2022-01-31 17:36:17+05:30  Cprogrammer
- * fixed args passed to post handle script
- *
- * Revision 1.3  2020-04-01 18:58:53+05:30  Cprogrammer
- * added encrypt flag argument to mkpasswd()
- *
- * Revision 1.2  2019-06-07 15:44:54+05:30  Cprogrammer
- * use sgetopt library for getopt()
- *
- * Revision 1.1  2019-04-14 22:41:20+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: vmoduser.c,v 1.18 2023-07-15 00:48:45+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -109,7 +56,7 @@
 #include "common.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: vmoduser.c,v 1.17 2023-03-23 22:20:51+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: vmoduser.c,v 1.18 2023-07-15 00:48:45+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "vmoduser: fatal: "
@@ -131,15 +78,15 @@ static char    *usage =
 	"         -h hash                  (use one of DES, MD5, SHA256, SHA512 hash)\n"
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	"         -m SCRAM method          (use one of SCRAM-SHA-1, SCRAM-SHA-256 SCRAM method)\n"
-	"         -C                       (Store clear txt and SCRAM hex salted passowrd in database\n"
+	"         -m SCRAM method          (use one of CRAM, SCRAM-SHA-1, SCRAM-SHA-256 SCRAM method)\n"
+	"         -C                       (Store clear txt / clear text and SCRAM hex salted passowrd in database)\n"
 	"         -S salt                  (Use a fixed base64 encoded salt)\n"
 	"         -I iter_count            (Use iter_count instead of default 4096 for generationg SCRAM password\n"
 #else
-	"         -C                       (Store clear txt passowrd in database\n"
+	"         -C                       (Store clear txt password in database)\n"
 #endif
 #else
-	"         -C                       (Store clear txt passowrd in database\n"
+	"         -C                       (Store clear txt password in database)\n"
 #endif
 	"         -D date format           (Delivery to a Date Folder)\n"
 	"         -l vacation_message_file (sets up Auto Responder)\n"
@@ -183,15 +130,16 @@ get_options(int argc, char **argv, stralloc *User, stralloc *Email, stralloc *Ge
 
 	*toggle = *ClearFlags = 0;
 	*QuotaFlag = 0;
-	*clear_text = 0;
+	if (clear_text)
+		*clear_text = 0;
 	if (salt)
 		*salt = 0;
 	if (docram)
 		*docram = 0;
 	if (scram)
-		*scram = 0;
+		*scram = -1;
 	if (iter)
-		*iter = 4096;
+		*iter = -1;
 	/*- make sure optstr has enough size to hold all options + 1 */
 	i = 0;
 	i += fmt_strn(optstr + i, "avutxHD:c:q:dpwisobr0123h:e:l:P:0123456789", 42);
@@ -229,7 +177,7 @@ get_options(int argc, char **argv, stralloc *User, stralloc *Email, stralloc *Ge
 				encrypt_flag = 0;
 			/*- flow through */
 		case 'P':
-			mkpasswd(*clear_text = optarg, enc_pass, encrypt_flag);
+			mkpasswd(clear_text ? *clear_text = optarg : optarg, enc_pass, encrypt_flag);
 			if (verbose) {
 				subprintfe(subfderr, "vmoduser", "encrypted password set as %s\n", enc_pass->s);
 				errflush("vmoduser");
@@ -248,7 +196,8 @@ get_options(int argc, char **argv, stralloc *User, stralloc *Email, stralloc *Ge
 			if (!str_diffn(optarg, "SHA-512", 7))
 				strnum[fmt_int(strnum, SHA512_HASH)] = 0;
 			else
-				strerr_die5x(100, WARN, "wrong hash method ", optarg, ". Supported HASH Methods: DES MD5 SHA-256 SHA-512\n", usage);
+				strerr_die5x(100, WARN, "wrong hash method ", optarg,
+						". Supported HASH Methods: DES MD5 SHA-256 SHA-512\n", usage);
 			if (!env_put2("PASSWORD_HASH", strnum))
 				strerr_die1x(111, "out of memory");
 			encrypt_flag = 1;
@@ -262,13 +211,17 @@ get_options(int argc, char **argv, stralloc *User, stralloc *Email, stralloc *Ge
 		case 'm':
 			if (!scram)
 				break;
-			if (!str_diffn(optarg, "SCRAM-SHA-1", 11))
+			if (!str_diffn(optarg, "CRAM", 5))
+				*scram = 0;
+			else
+			if (!str_diffn(optarg, "SCRAM-SHA-1", 12))
 				*scram = 1;
 			else
-			if (!str_diffn(optarg, "SCRAM-SHA-256", 13))
+			if (!str_diffn(optarg, "SCRAM-SHA-256", 14))
 				*scram = 2;
 			else
-				strerr_die5x(100, WARN, "wrong SCRAM method ", optarg, ". Supported SCRAM Methods: SCRAM-SHA1 SCRAM-SHA-256\n", usage);
+				strerr_die5x(100, WARN, "wrong SCRAM method ", optarg,
+						". Supported CRAM Methods: CRAM, SCRAM-SHA1 SCRAM-SHA-256\n", usage);
 			break;
 		case 'S':
 			if (!salt)
@@ -368,6 +321,8 @@ get_options(int argc, char **argv, stralloc *User, stralloc *Email, stralloc *Ge
 		strerr_die2x(100, WARN, usage);
 	if (encrypt_flag == -1)
 		encrypt_flag = 1;
+	if (docram && *docram && !*clear_text)
+		strerr_die3x(100, WARN, "Password not provided\n", usage);
 	return (0);
 }
 
@@ -376,14 +331,14 @@ main(int argc, char **argv)
 {
 	static stralloc Email = {0}, User = {0}, Domain = {0}, Gecos = {0},
 					enc_pass = {0}, DateFormat = {0}, Quota = {0}, vacation_file = {0},
-					tmpbuf = {0}, tmpQuota = {0};
+					tmpbuf = {0}, tmpQuota = {0}, result = {0};
 	int             GidFlag = 0, QuotaFlag = 0, toggle = 0, ClearFlags,
-					set_vacation = 0, err, fd, i;
+					set_vacation = 0, err, fd, i, docram;
 	uid_t           uid, domainuid;
 	gid_t           gid, domaingid;
 	struct passwd   PwTmp;
 	struct passwd  *pw;
-	char           *real_domain, *ptr;
+	char           *real_domain, *ptr, *clear_text;
 	char            strnum1[FMT_ULONG], strnum2[FMT_ULONG];
 	mdir_t          quota = 0, ul;
 #ifdef USE_MAILDIRQUOTA
@@ -392,13 +347,12 @@ main(int argc, char **argv)
 #ifdef ENABLE_DOMAIN_LIMITS
 	static stralloc TheDir = {0};
 	struct vlimits  limits;
-	int             domain_limits, docram;
+	int             domain_limits;
 #endif
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	static stralloc result = {0};
-	char           *b64salt, *clear_text;
-	int             scram, iter;
+	char           *b64salt = NULL, *b64salt_t = NULL;
+	int             scram, iter = -1, iter_t = -1;
 #endif
 #endif
 
@@ -411,13 +365,13 @@ main(int argc, char **argv)
 #else
 	if (get_options(argc, argv, &User, &Email, &Gecos, &enc_pass,
 			&DateFormat, &Quota, &vacation_file, &toggle, &GidFlag, &ClearFlags,
-			&QuotaFlag, &set_vacation, &docram, 0, 0, 0, 0))
+			&QuotaFlag, &set_vacation, &docram, &clear_text, 0, 0, 0))
 		return (1);
 #endif
 #else
 	if (get_options(argc, argv, &User, &Email, &Gecos, &enc_pass,
 			&DateFormat, &Quota, &vacation_file, &toggle, &GidFlag, &ClearFlags,
-			&QuotaFlag, &set_vacation, docram, 0, 0, 0, 0))
+			&QuotaFlag, &set_vacation, docram, &clear_text, 0, 0, 0))
 		return (1);
 #endif
 	parse_email(Email.s, &User, &Domain);
@@ -434,23 +388,6 @@ main(int argc, char **argv)
 		strnum2[fmt_ulong(strnum2, domaingid)] = 0;
 		strerr_die6x(100, WARN, "you must be root or domain user (uid=", strnum1, ", gid=", strnum2, ") to run this program");
 	}
-#ifdef HAVE_GSASL
-#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	if (clear_text) {
-		switch (scram)
-		{
-		case 1: /*- SCRAM-SHA-1 */
-			if ((i = gsasl_mkpasswd(verbose, "SCRAM-SHA-1", iter, b64salt, docram, clear_text, &result)) != NO_ERR)
-				strerr_die2x(111, "gsasl error: ", gsasl_mkpasswd_err(i));
-			break;
-		case 2: /*- SCRAM-SHA-256 */
-			if ((i = gsasl_mkpasswd(verbose, "SCRAM-SHA-256", iter, b64salt, docram, clear_text, &result)) != NO_ERR)
-				strerr_die2x(111, "gsasl error: ", gsasl_mkpasswd_err(i));
-			break;
-		}
-	}
-#endif
-#endif
 	if (QuotaFlag == 1 || set_vacation) {
 		if (uid && setuid(0))
 			strerr_die2sys(111, FATAL, "setuid-root: ");
@@ -491,12 +428,53 @@ main(int argc, char **argv)
 			strerr_die3x(1, WARN, "quota modification not allowed for ", Email.s);
 	}
 #endif
+#ifdef HAVE_GSASL
+#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
+	if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-1}", 13) || !str_diffn(pw->pw_passwd, "{SCRAM-SHA-256}", 15))
+		i = get_scram_secrets(pw->pw_passwd, 0, &iter_t, &b64salt_t, 0, 0, 0, 0, &ptr);
+	else
+		i = 0;
+	if (i == 8)
+		docram = 1;
+	if (scram == -1) {
+		if (!str_diffn(pw->pw_passwd, "{CRAM}", 6))
+			scram = 0;
+		else
+		if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-1}", 13))
+			scram = 1;
+		else
+		if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-256}", 15))
+			scram = 2;
+	}
+	if (clear_text) {
+		if (!b64salt && b64salt_t)
+			b64salt = b64salt_t;
+		if (iter == -1 && iter_t > 0)
+			iter = iter_t;
+		else
+		if (iter == -1)
+			iter = 4096;
+		switch (scram)
+		{
+		case 1: /*- SCRAM-SHA-1 */
+			if ((i = gsasl_mkpasswd(verbose, "SCRAM-SHA-1", iter, b64salt, docram, clear_text, &result)) != NO_ERR)
+				strerr_die2x(111, "gsasl error: ", gsasl_mkpasswd_err(i));
+			break;
+		case 2: /*- SCRAM-SHA-256 */
+			if ((i = gsasl_mkpasswd(verbose, "SCRAM-SHA-256", iter, b64salt, docram, clear_text, &result)) != NO_ERR)
+				strerr_die2x(111, "gsasl error: ", gsasl_mkpasswd_err(i));
+			break;
+		}
+	}
+#endif
+#endif
 	PwTmp = *pw; /*- structure copy */
 	pw = &PwTmp;
 	if (Gecos.len)
 		pw->pw_gecos = Gecos.s;
 	if (enc_pass.len)
 		pw->pw_passwd = enc_pass.s;
+	else
 	if (!str_diffn(pw->pw_passwd, "{SCRAM-SHA-1}", 13) || !str_diffn(pw->pw_passwd, "{SCRAM-SHA-256}", 15)) {
 		i = get_scram_secrets(pw->pw_passwd, 0, 0, 0, 0, 0, 0, 0, &ptr);
 		if (i != 6 && i != 8)
@@ -555,13 +533,20 @@ main(int argc, char **argv)
 #endif
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	ptr = scram ? result.s : 0;
+	ptr = scram > 0 ? result.s : 0;
 #else
 	ptr = (char *) NULL;
 #endif
 #else
 	ptr = (char *) NULL;
 #endif
+	if (!ptr && docram) {
+		if (!stralloc_copyb(&result, "{CRAM}", 6) ||
+				!stralloc_cats(&result, clear_text) ||
+				!stralloc_0(&result))
+			die_nomem();
+		ptr = result.s;
+	}
 	if ((Gecos.len || enc_pass.len || ClearFlags || GidFlag || QuotaFlag) &&
 			(err = sql_setpw(pw, real_domain, ptr)))
 		strerr_die2x(1, FATAL, "sql_setpw failed");
@@ -646,3 +631,63 @@ main(int argc, char **argv)
 	}
 	return (err);
 }
+
+/*
+ * $Log: vmoduser.c,v $
+ * Revision 1.18  2023-07-15 00:48:45+05:30  Cprogrammer
+ * Set password for CRAM authentication with {CRAM} prefix
+ *
+ * Revision 1.17  2023-03-23 22:20:51+05:30  Cprogrammer
+ * removed incorrect call to vdeldomain
+ *
+ * Revision 1.16  2023-03-22 10:43:02+05:30  Cprogrammer
+ * run POST_HANDLE program (if set) with domain user uid/gid
+ *
+ * Revision 1.15  2023-01-22 10:40:03+05:30  Cprogrammer
+ * replaced qprintf with subprintf
+ *
+ * Revision 1.14  2022-11-08 17:17:56+05:30  Cprogrammer
+ * removed compiler warning for unused variable
+ *
+ * Revision 1.13  2022-11-02 12:45:15+05:30  Cprogrammer
+ * set usage string depeding on gsasl availability
+ *
+ * Revision 1.12  2022-10-20 11:59:07+05:30  Cprogrammer
+ * converted function prototype to ansic
+ *
+ * Revision 1.11  2022-09-14 13:41:26+05:30  Cprogrammer
+ * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
+ *
+ * Revision 1.10  2022-08-28 15:11:23+05:30  Cprogrammer
+ * fix compilation error for non gsasl build
+ *
+ * Revision 1.9  2022-08-25 18:07:49+05:30  Cprogrammer
+ * Make password compatible with CRAM and SCRAM
+ * 1. store hex-encoded salted password for setting GSASL_SCRAM_SALTED_PASSWORD property in libgsasl
+ * 2. store clear text password for CRAM authentication methods
+ *
+ * Revision 1.8  2022-08-24 18:35:17+05:30  Cprogrammer
+ * made setting hash method and scram method independent
+ *
+ * Revision 1.7  2022-08-07 20:41:18+05:30  Cprogrammer
+ * check return value of gsasl_mkpasswd() function
+ *
+ * Revision 1.6  2022-08-07 13:06:42+05:30  Cprogrammer
+ * added option to set scram password
+ *
+ * Revision 1.5  2022-08-05 21:20:58+05:30  Cprogrammer
+ * reversed encrypt_flag setting for mkpasswd() change in encrypt_flag
+ *
+ * Revision 1.4  2022-01-31 17:36:17+05:30  Cprogrammer
+ * fixed args passed to post handle script
+ *
+ * Revision 1.3  2020-04-01 18:58:53+05:30  Cprogrammer
+ * added encrypt flag argument to mkpasswd()
+ *
+ * Revision 1.2  2019-06-07 15:44:54+05:30  Cprogrammer
+ * use sgetopt library for getopt()
+ *
+ * Revision 1.1  2019-04-14 22:41:20+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/vpasswd.9
+++ b/indimail-x/vpasswd.9
@@ -56,7 +56,7 @@ methods.
 
 .TP
 \fB\-h\fR \fIhash\fR
-Specifiy hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
+Specify hash which is one of DES, MD5, SHA-256, SHA-512. Here \fIID\fR is
 the id in \fI/etc/shadow\fR. See \fBincrypt\fR(1).
 .TS
 l l.
@@ -68,14 +68,35 @@ SHA-256 5  SHA256 encryption
 SHA-512 6  SHA512 encryption
 .TE
 
-.TP
+You can also set the environment variable \fBPASSWORD_HASH\fR to set the
+encryption method. The -h argument overrides the environment variable
+\fBPASSWORD_HASH\fR. The value of \fBPASSWORD_HASH\fR environment variable
+identifies the encryption method used and this then determines how the rest
+of the password string is interpreted. The following values of
+\fBPASSWORD_HASH\fR are supported:
+
+.nf
+.ta 5c 10c
+PASSWORD_HASH Value	Description
+0	DES encryption (shouldn't be used)
+1	MD5 encryption (shouldn't be used)
+2	SHA256 encryption
+3	SHA512 encryption
+.fi
+.RE
+
+.TP 3
 \fB\-m\fR \fIscram\fR
-Specifiy scram method which is one of SCRAM-SHA-1, SCRAM-SHA-256
+Sets the CRAM or SCRAM method for encryption. This will set SCRAM password in
+the \fIscram\fR field in indimail/indibak tables. For CRAM method, it will
+set clear text password when -C option is specified.
 .RS
 .nf
 .ta 5c 10c
-SCRAM method	Description
--------------	-----------
+CRAM/SCRAM method	Description
+-----------------	-----------
+CRAM	Sets clear text password suitable for any
+	CRAM method (CRAM-MD5, CRAM-SHA1, ...)
 SCRAM-SHA-1	SHA1 encryption suitable for SCRAM-SHA-1.
 SCRAM-SHA-256	SHA256 encryption suitable for SCRAM-SHA-256.
 .fi

--- a/indimail-x/vpasswd.c
+++ b/indimail-x/vpasswd.c
@@ -1,58 +1,5 @@
 /*
- * $Log: vpasswd.c,v $
- * Revision 1.17  2023-01-22 10:30:38+05:30  Cprogrammer
- * reformatted error message
- *
- * Revision 1.16  2022-11-02 12:45:58+05:30  Cprogrammer
- * set usage string depeding on gsasl availability
- *
- * Revision 1.15  2022-10-20 11:59:10+05:30  Cprogrammer
- * converted function prototype to ansic
- *
- * Revision 1.14  2022-09-13 22:10:17+05:30  Cprogrammer
- * formated usage
- *
- * Revision 1.13  2022-08-28 15:28:18+05:30  Cprogrammer
- * fix compilation error for non gsasl build
- *
- * Revision 1.12  2022-08-25 18:06:36+05:30  Cprogrammer
- * Make password compatible with CRAM and SCRAM
- * 1. store hex-encoded salted password for setting GSASL_SCRAM_SALTED_PASSWORD property in libgsasl
- * 2. store clear text password for CRAM authentication
- *
- * Revision 1.11  2022-08-24 18:35:53+05:30  Cprogrammer
- * made setting hash method and scram method independent
- *
- * Revision 1.10  2022-08-07 20:40:51+05:30  Cprogrammer
- * check return value of gsasl_mkpasswd() function
- *
- * Revision 1.9  2022-08-07 13:12:16+05:30  Cprogrammer
- * updated usage string
- *
- * Revision 1.8  2022-08-06 19:34:25+05:30  Cprogrammer
- * fix compilation when libgsasl is missing or of wrong version
- *
- * Revision 1.7  2022-08-06 11:19:07+05:30  Cprogrammer
- * include gsasl.h
- *
- * Revision 1.6  2022-08-05 23:39:53+05:30  Cprogrammer
- * compile gsasl code for libgsasl version >= 1.8.1
- *
- * Revision 1.5  2022-08-05 23:15:01+05:30  Cprogrammer
- * conditional compilation of gsasl code
- *
- * Revision 1.4  2022-08-05 21:21:57+05:30  Cprogrammer
- * added option to update scram passwords
- *
- * Revision 1.3  2020-04-01 18:59:07+05:30  Cprogrammer
- * moved authentication functions to libqmail
- *
- * Revision 1.2  2019-06-07 15:44:30+05:30  Cprogrammer
- * use sgetopt library for getopt()
- *
- * Revision 1.1  2019-04-14 18:29:31+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: vpasswd.c,v 1.18 2023-07-15 00:31:13+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -89,7 +36,7 @@
 #include "common.h"
 
 #ifndef	lint
-static char     sccsid[] = "$Id: vpasswd.c,v 1.17 2023-01-22 10:30:38+05:30 Cprogrammer Exp mbhangui $";
+static char     sccsid[] = "$Id: vpasswd.c,v 1.18 2023-07-15 00:31:13+05:30 Cprogrammer Exp mbhangui $";
 #endif
 
 #define FATAL   "vpasswd: fatal: "
@@ -128,14 +75,14 @@ get_options(int argc, char **argv, char **email, char **clear_text,
 	char            optstr[15], strnum[FMT_ULONG];
 
 	*email = *clear_text = 0;
+	if (docram)
+		*docram = 0;
+	if (scram)
+		*scram = -1;
 	if (salt)
 		*salt = 0;
 	if (iter)
 		*iter = 4096;
-	if (scram)
-		*scram = 0;
-	if (docram)
-		*docram = 0;
 	*encrypt_flag = -1;
 	Random = 0;
 	/*- make sure optstr has enough size to hold all options + 1 */
@@ -182,6 +129,9 @@ get_options(int argc, char **argv, char **email, char **clear_text,
 		case 'm':
 			if (!scram)
 				break;
+			if (!str_diffn(optarg, "CRAM", 5))
+				*scram = 0;
+			else
 			if (!str_diffn(optarg, "SCRAM-SHA-1", 11))
 				*scram = 1;
 			else
@@ -251,11 +201,10 @@ main(int argc, char **argv)
 {
 	int             i, encrypt_flag, docram;
 	char           *real_domain, *ptr, *email, *clear_text, *base_argv0;
-	static stralloc user = {0}, domain = {0};
+	static stralloc user = {0}, domain = {0}, result = {0};
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
 	int             scram, iter;
-	static stralloc result = {0};
 	char           *b64salt;
 #endif
 #endif
@@ -295,13 +244,20 @@ main(int argc, char **argv)
 		break;
 	/*- more cases will get below when devils come up with a new RFC */
 	}
-	ptr = scram ? result.s : 0;
+	ptr = scram > 0 ? result.s : 0;
 #else
 	ptr = 0;
 #endif
 #else
 	ptr = 0;
 #endif
+	if (!ptr && docram) {
+		if (!stralloc_copyb(&result, "{CRAM}", 6) ||
+				!stralloc_cats(&result, clear_text) ||
+				!stralloc_0(&result))
+			strerr_die2x(111, FATAL, "out of memory");
+		ptr = result.s;
+	}
 	if ((i = ipasswd(user.s, real_domain, clear_text, encrypt_flag, ptr)) != 1) {
 		if (!i)
 			strerr_warn5("vpasswd: ", user.s, "@", real_domain, ": No such user", 0);
@@ -321,3 +277,63 @@ main(int argc, char **argv)
 	} else
 		return (post_handle("%s %s@%s", ptr, user.s, real_domain));
 }
+
+/*
+ * $Log: vpasswd.c,v $
+ * Revision 1.18  2023-07-15 00:31:13+05:30  Cprogrammer
+ * Set password for CRAM authentication with {CRAM} prefix
+ *
+ * Revision 1.17  2023-01-22 10:30:38+05:30  Cprogrammer
+ * reformatted error message
+ *
+ * Revision 1.16  2022-11-02 12:45:58+05:30  Cprogrammer
+ * set usage string depeding on gsasl availability
+ *
+ * Revision 1.15  2022-10-20 11:59:10+05:30  Cprogrammer
+ * converted function prototype to ansic
+ *
+ * Revision 1.14  2022-09-13 22:10:17+05:30  Cprogrammer
+ * formated usage
+ *
+ * Revision 1.13  2022-08-28 15:28:18+05:30  Cprogrammer
+ * fix compilation error for non gsasl build
+ *
+ * Revision 1.12  2022-08-25 18:06:36+05:30  Cprogrammer
+ * Make password compatible with CRAM and SCRAM
+ * 1. store hex-encoded salted password for setting GSASL_SCRAM_SALTED_PASSWORD property in libgsasl
+ * 2. store clear text password for CRAM authentication
+ *
+ * Revision 1.11  2022-08-24 18:35:53+05:30  Cprogrammer
+ * made setting hash method and scram method independent
+ *
+ * Revision 1.10  2022-08-07 20:40:51+05:30  Cprogrammer
+ * check return value of gsasl_mkpasswd() function
+ *
+ * Revision 1.9  2022-08-07 13:12:16+05:30  Cprogrammer
+ * updated usage string
+ *
+ * Revision 1.8  2022-08-06 19:34:25+05:30  Cprogrammer
+ * fix compilation when libgsasl is missing or of wrong version
+ *
+ * Revision 1.7  2022-08-06 11:19:07+05:30  Cprogrammer
+ * include gsasl.h
+ *
+ * Revision 1.6  2022-08-05 23:39:53+05:30  Cprogrammer
+ * compile gsasl code for libgsasl version >= 1.8.1
+ *
+ * Revision 1.5  2022-08-05 23:15:01+05:30  Cprogrammer
+ * conditional compilation of gsasl code
+ *
+ * Revision 1.4  2022-08-05 21:21:57+05:30  Cprogrammer
+ * added option to update scram passwords
+ *
+ * Revision 1.3  2020-04-01 18:59:07+05:30  Cprogrammer
+ * moved authentication functions to libqmail
+ *
+ * Revision 1.2  2019-06-07 15:44:30+05:30  Cprogrammer
+ * use sgetopt library for getopt()
+ *
+ * Revision 1.1  2019-04-14 18:29:31+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/indimail-x/vpasswd.c
+++ b/indimail-x/vpasswd.c
@@ -109,7 +109,11 @@ static char    *usage =
 	"  -S salt         - use a fixed base64 encoded salt for generating SCRAM password\n"
 	"                  - if salt is not specified, it will be generated\n"
 	"  -I iter_count   - use iter_count instead of 4096 for generating SCRAM password\n"
+#else
+	"  -C              - store clear txt password in database\n"
 #endif
+#else
+	"  -C              - store clear txt password in database\n"
 #endif
 	"  -v              - sets verbose output\n"
 	"  -H              - display this usage"
@@ -136,10 +140,10 @@ get_options(int argc, char **argv, char **email, char **clear_text,
 	Random = 0;
 	/*- make sure optstr has enough size to hold all options + 1 */
 	i = 0;
-	i += fmt_strn(optstr + i, "Hveh:r:", 7);
+	i += fmt_strn(optstr + i, "Hveh:r:C", 8);
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	i += fmt_strn(optstr + i, "Cm:S:I:", 7);
+	i += fmt_strn(optstr + i, "m:S:I:", 6);
 #endif
 #endif
 	if ((i + 1) > sizeof(optstr))
@@ -169,12 +173,12 @@ get_options(int argc, char **argv, char **email, char **clear_text,
 				strerr_die1x(111, "out of memory");
 			*encrypt_flag = 1;
 			break;
-#ifdef HAVE_GSASL
-#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
 		case 'C':
 			if (docram)
 				*docram = 1;
 			break;
+#ifdef HAVE_GSASL
+#if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
 		case 'm':
 			if (!scram)
 				break;
@@ -245,12 +249,12 @@ get_options(int argc, char **argv, char **email, char **clear_text,
 int
 main(int argc, char **argv)
 {
-	int             i, encrypt_flag;
+	int             i, encrypt_flag, docram;
 	char           *real_domain, *ptr, *email, *clear_text, *base_argv0;
 	static stralloc user = {0}, domain = {0};
 #ifdef HAVE_GSASL
 #if GSASL_VERSION_MAJOR == 1 && GSASL_VERSION_MINOR > 8 || GSASL_VERSION_MAJOR > 1
-	int             scram, iter, docram;
+	int             scram, iter;
 	static stralloc result = {0};
 	char           *b64salt;
 #endif
@@ -260,11 +264,11 @@ main(int argc, char **argv)
 	if (get_options(argc, argv, &email, &clear_text, &encrypt_flag, &docram, &scram, &iter, &b64salt))
 		return (1);
 #else
-	if (get_options(argc, argv, &email, &clear_text, &encrypt_flag, 0, 0, 0, 0))
+	if (get_options(argc, argv, &email, &clear_text, &encrypt_flag, docram, 0, 0, 0))
 		return (1);
 #endif
 #else
-	if (get_options(argc, argv, &email, &clear_text, &encrypt_flag, 0, 0, 0, 0))
+	if (get_options(argc, argv, &email, &clear_text, &encrypt_flag, docram, 0, 0, 0))
 		return (1);
 #endif
 	parse_email(email, &user, &domain);

--- a/indimail-x/vsetpass.c
+++ b/indimail-x/vsetpass.c
@@ -1,36 +1,5 @@
 /*
- * $Log: vsetpass.c,v $
- * Revision 1.10  2023-06-17 23:48:02+05:30  Cprogrammer
- * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
- *
- * Revision 1.9  2023-01-22 10:40:03+05:30  Cprogrammer
- * replaced qprintf with subprintf
- *
- * Revision 1.8  2022-09-14 08:48:10+05:30  Cprogrammer
- * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
- *
- * Revision 1.7  2022-08-05 21:23:42+05:30  Cprogrammer
- * reversed encrypt_flag setting for mkpasswd() change in encrypt_flag
- *
- * Revision 1.6  2021-07-22 15:17:42+05:30  Cprogrammer
- * conditional define of _XOPEN_SOURCE
- *
- * Revision 1.5  2020-09-28 13:28:36+05:30  Cprogrammer
- * added pid in debug statements
- *
- * Revision 1.4  2020-09-28 12:50:12+05:30  Cprogrammer
- * removed extra newline
- *
- * Revision 1.3  2020-04-01 18:59:14+05:30  Cprogrammer
- * added encrypt flag argument to mkpasswd()
- * moved authentication functions to libqmail
- *
- * Revision 1.2  2019-07-10 12:58:10+05:30  Cprogrammer
- * print more error information in print_error
- *
- * Revision 1.1  2019-04-18 08:37:39+05:30  Cprogrammer
- * Initial revision
- *
+ * $Id: $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -242,10 +211,17 @@ main(int argc, char **argv)
 			flush("vsetpass");
 			strerr_die1(1, "vsetpass: unable to get secrets", 0);
 		}
-	} else {
-		i = 0;
+	} else
+	if (!str_diffn(pw->pw_passwd, "{CRAM}", 6)) {
+		pw->pw_passwd += 6;
+		i = str_rchr(pw->pw_passwd, ':');
+		if (pw->pw_passwd[i]) {
+			pw->pw_passwd[i] = 0;
+			pw->pw_passwd += (i + 1);
+		} 
 		crypt_pass = pw->pw_passwd;
-	}
+	} else
+		crypt_pass = pw->pw_passwd;
 #else
 	crypt_pass = pw->pw_passwd;
 #endif
@@ -294,3 +270,38 @@ main(int argc, char **argv)
 	}
 	return(i == 1 ? 0 : 1);
 }
+
+/*
+ * $Log: vsetpass.c,v $
+ * Revision 1.10  2023-06-17 23:48:02+05:30  Cprogrammer
+ * set PASSWORD_HASH to make pw_comp use crypt() instead of in_crypt()
+ *
+ * Revision 1.9  2023-01-22 10:40:03+05:30  Cprogrammer
+ * replaced qprintf with subprintf
+ *
+ * Revision 1.8  2022-09-14 08:48:10+05:30  Cprogrammer
+ * extract encrypted password from pw->pw_passwd starting with {SCRAM-SHA.*}
+ *
+ * Revision 1.7  2022-08-05 21:23:42+05:30  Cprogrammer
+ * reversed encrypt_flag setting for mkpasswd() change in encrypt_flag
+ *
+ * Revision 1.6  2021-07-22 15:17:42+05:30  Cprogrammer
+ * conditional define of _XOPEN_SOURCE
+ *
+ * Revision 1.5  2020-09-28 13:28:36+05:30  Cprogrammer
+ * added pid in debug statements
+ *
+ * Revision 1.4  2020-09-28 12:50:12+05:30  Cprogrammer
+ * removed extra newline
+ *
+ * Revision 1.3  2020-04-01 18:59:14+05:30  Cprogrammer
+ * added encrypt flag argument to mkpasswd()
+ * moved authentication functions to libqmail
+ *
+ * Revision 1.2  2019-07-10 12:58:10+05:30  Cprogrammer
+ * print more error information in print_error
+ *
+ * Revision 1.1  2019-04-18 08:37:39+05:30  Cprogrammer
+ * Initial revision
+ *
+ */

--- a/iwebadmin-x/iwebadmin.c
+++ b/iwebadmin-x/iwebadmin.c
@@ -1,5 +1,8 @@
 /*
  * $Log: iwebadmin.c,v $
+ * Revision 1.33  2023-07-14 21:47:28+05:30  Cprogrammer
+ * set scram to 0 if passwd field starts with {CRAM}
+ *
  * Revision 1.32  2022-10-25 11:52:50+05:30  Cprogrammer
  * update b64salt from database
  *
@@ -55,7 +58,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
  *
- * $Id: iwebadmin.c,v 1.32 2022-10-25 11:52:50+05:30 Cprogrammer Exp mbhangui $
+ * $Id: iwebadmin.c,v 1.33 2023-07-14 21:47:28+05:30 Cprogrammer Exp mbhangui $
  */
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -124,7 +127,7 @@ stralloc        Username = {0}, Domain = {0}, Password = {0}, Gecos = {0},
 				b64salt = {0}, result = {0};
 int             CGIValues[256];
 int             ezmlm_idx = -1, ezmlm_make = -1, debug = 0, enable_fortune = 1,
-				scram = 0, u_scram = 0, cram = 0, iter_count = 4096;
+				scram = -1, u_scram = 0, cram = 0, iter_count = 4096;
 time_t          mytime;
 char           *TmpCGI = NULL;
 int             Compressed;
@@ -293,6 +296,9 @@ conf_iwebadmin()
 			else
 			if (!str_diffn(line.s, "debug", 5))
 				debug = 1;
+			if (!str_diffn(line.s, "cram", 5))
+				scram = 0;
+			else
 			if (!str_diffn(line.s, "scram-sha-1", 12))
 				scram = 1;
 			else

--- a/iwebadmin-x/iwebadmin.spec.in
+++ b/iwebadmin-x/iwebadmin.spec.in
@@ -1,6 +1,6 @@
 #
 #
-# $Id: iwebadmin.spec.in,v 1.52 2022-11-02 16:55:15+05:30 Cprogrammer Exp mbhangui $
+# $Id: iwebadmin.spec.in,v 1.53 2023-07-14 21:49:19+05:30 Cprogrammer Exp mbhangui $
 %undefine _missing_build_ids_terminate_build
 %define _unpackaged_files_terminate_build 1
 

--- a/iwebadmin-x/template.c
+++ b/iwebadmin-x/template.c
@@ -1,5 +1,5 @@
 /*
- * $Id: template.c,v 1.27 2022-10-25 11:53:10+05:30 Cprogrammer Exp mbhangui $
+ * $Id: template.c,v 1.28 2023-07-14 21:50:08+05:30 Cprogrammer Exp mbhangui $
  * Copyright (C) 1999-2004 Inter7 Internet Technologies, Inc. 
  *
  * This program is free software; you can redistribute it and/or modify
@@ -528,6 +528,9 @@ send_template_now(char *filename)
 						printh("%d", iter_count);
 						break;
 					case '2':
+						if (scram == 0)
+							printh("%H", "cram");
+						else
 						if (scram == 1)
 							printh("%H", "scram-sha-1");
 						else
@@ -917,6 +920,12 @@ check_mailbox_flags(char newchar)
 		vpw->pw_passwd = ptr;
 		if (salt && (!stralloc_copys(&b64salt, salt) || !stralloc_0(&b64salt)))
 			die_nomem();
+	} else
+	if (!str_diffn(vpw->pw_passwd, "{CRAM}", 6)) {
+		vpw->pw_passwd += 6;
+		i = str_rchr(vpw->pw_passwd, ',');
+		if (vpw->pw_passwd[i])
+			vpw->pw_passwd += (i + 1);
 	} else
 		i = 0;
 	switch (newchar)


### PR DESCRIPTION
1. Use scram field in indimail table to store clear text passwords for CRAM authentication with prefix {CRAM}
2. iwebadmin-x/iwebadmin.c: set scram to 0 if passwd field starts with {CRAM}
3. iwebadmin-x/tempate.c: handle password field starting with {CRAM}
4. iwebadmin-x/user.c: set password field to start with {CRAM} when adding/modifying clear text passwords for CRAM authentication
5. indimail-x/userinfo.c: Display clear text passwords for CRAM with label CRAM
6. indimail-x/authindi.c, vchkpass.c, iauth.c, proxylogin.c: authenticate using CRAM when password field starts with {CRAM}
7. indimail-x/renameuser.c: copy scram field from old user to new user when renaming user
8. indimail-x/vmoduser.c, vadddomain.c, vadduser.c, vgroup.c, vpasswd.c, vsetpass.c: Set password for CRAM authentication with {CRAM} prefix
9. indimail-x/sql_setpw.c: extract encrypted password from pw->pw_passwd starting with {CRAM}
10. indimail-x/tests/testindimail-virtual: add test case for CRAM passwords